### PR TITLE
WifiControl: Add PROTO and PAIR keys with WPA-PSK support

### DIFF
--- a/WifiControl/Network.cpp
+++ b/WifiControl/Network.cpp
@@ -108,7 +108,7 @@ namespace WPASupplicant {
 
     bool Config::PresharedKey(const string& presharedKey)
     {
-        return ((SetKey(KEY, _T("WPA-PSK"))) && (SetKey(PAIR, _T("CCMP"))) && (SetKey(PROTO, _T("RSN"))) && (SetKey(AUTH, _T("OPEN"))) && (SetKey(SSIDKEY, ('\"' + _ssid + '\"'))) && (SetKey(PSK, ('\"' + presharedKey + '\"'))));
+        return ((SetKey(KEY, _T("WPA-PSK"))) && (SetKey(PAIR, _T("CCMP TKIP"))) && (SetKey(PROTO, _T("WPA RSN"))) && (SetKey(AUTH, _T("OPEN"))) && (SetKey(SSIDKEY, ('\"' + _ssid + '\"'))) && (SetKey(PSK, ('\"' + presharedKey + '\"'))));
     }
 
     bool Config::Enterprise(const string& identity, const string& password)


### PR DESCRIPTION
Currently the WifiControl WPA-PSK mode is not working with WPA-PSK(TKP). Added required changes to support this as well.