### PR TITLE
[IOConnector] Fix handler's Start/Stop integer size

### DIFF
--- a/IOConnector/IOConnector.h
+++ b/IOConnector/IOConnector.h
@@ -172,8 +172,8 @@ namespace Plugin {
                 public:
                     Core::JSON::String Name;
                     Core::JSON::String Config;
-                    Core::JSON::DecUInt8 Start;
-                    Core::JSON::DecUInt8 End;
+                    Core::JSON::DecUInt32 Start;
+                    Core::JSON::DecUInt32 End;
                 };
 
                 enum mode {


### PR DESCRIPTION
All internal variables for dealing with the handler's 'Start' and 'Stop'
settings are 'uint32_t', but the associated members in the respective
config class are 'Core::JSON::DecUInt8', which results in undesired
values (wrap around, truncated) for values larger than 255 (MAX_UINT8).

This way, use 'Core::JSON::DecUInt32' instead on the config class.