### PR TITLE
Spark: RPC connection time need to be increaed with 1 more second

### DIFF
--- a/Spark/Spark.cpp
+++ b/Spark/Spark.cpp
@@ -55,7 +55,7 @@ namespace Plugin {
         // instantiation.
         _service->Register(&_notification);
 
-        _spark = _service->Root<Exchange::IBrowser>(_connectionId, 2000, _T("SparkImplementation"));
+        _spark = _service->Root<Exchange::IBrowser>(_connectionId, 3000, _T("SparkImplementation"));
 
         if (_spark != nullptr) {
 


### PR DESCRIPTION
With latest pxcore library it need 3000 seconds to laugh Spark plugin