### PR TITLE
Compositor:Wayland: repeated ZOrder and SetInput calls are removed, s…

### DIFF
--- a/Compositor/lib/Wayland/Wayland.cpp
+++ b/Compositor/lib/Wayland/Wayland.cpp
@@ -422,8 +422,6 @@ namespace Plugin {
                     std::list<Exchange::IComposition::INotification*>::iterator index(_compositionClients.begin());
 
                     while (index != _compositionClients.end()) {
-                        entry->ZOrder(0);
-                        entry->SetInput();
                         (*index)->Attached(entry->Name(), entry);
                         index++;
                     }


### PR DESCRIPTION
…ince it is calling from Compositor:Attached sequence as well