### PR TITLE
NetworkControl: avoid IP request from the dispatcher loop, since it ending with deadlock

### DIFF
--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -521,8 +521,8 @@ namespace Plugin
             } else {
                 std::map<const string, Core::ProxyType<DHCPEngine>>::iterator entry(_dhcpInterfaces.find(interfaceName));
 
-                if (entry != _dhcpInterfaces.end()) {                    
-
+                if (entry != _dhcpInterfaces.end()) {
+                    entry->second->StopWatchdog();
                     entry->second->GetIP();
                     result = Core::ERROR_NONE;
                 }

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -460,9 +460,6 @@ namespace Plugin {
                             // Remove unresponsive offer from potential candidates
                             DHCPClientImplementation::Offer copy = offer.Current(); 
                             _client.RemoveUnleasedOffer(offer.Current());
-                            
-                            // Inform controller that request failed
-                            _parent.RequestFailed(_client.Interface(), copy);
                         }
                     }
                 }

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -344,7 +344,7 @@ namespace Plugin {
 
             inline uint32_t Discover(const Core::NodeId& preferred)
             {
-                ResetWatchdog();
+                SetupWatchdog();
                 uint32_t result = _client.Discover(preferred);
 
                 return (result);
@@ -367,6 +367,7 @@ namespace Plugin {
             }
 
             void NewOffer(const DHCPClientImplementation::Offer& offer) {
+                StopWatchdog();
                 if (_parent.NewOffer(_client.Interface(), offer) == true) {
                     Request(offer);
                 }
@@ -389,7 +390,7 @@ namespace Plugin {
 
             inline void Request(const DHCPClientImplementation::Offer& offer) {
 
-                ResetWatchdog();
+                SetupWatchdog();
                 _client.Request(offer);
             }
 
@@ -423,12 +424,6 @@ namespace Plugin {
                 Core::IWorkerPool::Instance().Revoke(Core::ProxyType<Core::IDispatch>(*this));
             }
 
-            inline void ResetWatchdog() 
-            {
-                StopWatchdog();
-                SetupWatchdog();
-            }
-
             void CleanUp() 
             {
                 StopWatchdog();
@@ -460,6 +455,7 @@ namespace Plugin {
                             // Remove unresponsive offer from potential candidates
                             DHCPClientImplementation::Offer copy = offer.Current(); 
                             _client.RemoveUnleasedOffer(offer.Current());
+                            _parent.RequestFailed(_client.Interface(), copy);
                         }
                     }
                 }


### PR DESCRIPTION
If start wlan0 in Dynamic mode with out a AP connected, this request will get failed and re request for IP using RequestFailed(). That will try to clear dispatcher using StopWatchdog(). But in this case this call will happened from the Dispatcher function only. Hence its creating a deadlock case.