### PR TITLE
Bluetooth: avoid static instance of ControlSocket

### DIFF
--- a/BluetoothControl/BluetoothControl.cpp
+++ b/BluetoothControl/BluetoothControl.cpp
@@ -28,8 +28,6 @@ namespace Plugin {
     static Core::ProxyPoolType<Web::JSONBodyType<BluetoothControl::DeviceImpl::Data>> jsonResponseFactoryDevice(1);
     static Core::ProxyPoolType<Web::JSONBodyType<BluetoothControl::Status>> jsonResponseFactoryStatus(1);
 
-    /* static */ BluetoothControl::ControlSocket* BluetoothControl::_appInstance;
-
     /* virtual */ const string BluetoothControl::Initialize(PluginHost::IShell* service)
     {
         string result;
@@ -46,7 +44,6 @@ namespace Plugin {
             result = Core::ToString(driverMessage);
         }
         else {
-            _appInstance = &_application;
             Bluetooth::ManagementSocket& administrator = _application.Control();
             Bluetooth::ManagementSocket::Devices(_adapters);
             administrator.DeviceId(_config.Interface.Value());
@@ -166,8 +163,6 @@ namespace Plugin {
         // We bring the interface up, so we should bring it down as well..
         _application.Close();
         ::destruct_bluetooth_driver();
-
-        _appInstance = nullptr;
     }
 
     /* virtual */ string BluetoothControl::Information() const

--- a/BluetoothControl/BluetoothControl.cpp
+++ b/BluetoothControl/BluetoothControl.cpp
@@ -28,7 +28,7 @@ namespace Plugin {
     static Core::ProxyPoolType<Web::JSONBodyType<BluetoothControl::DeviceImpl::Data>> jsonResponseFactoryDevice(1);
     static Core::ProxyPoolType<Web::JSONBodyType<BluetoothControl::Status>> jsonResponseFactoryStatus(1);
 
-    /* static */ BluetoothControl::ControlSocket BluetoothControl::_application;
+    /* static */ BluetoothControl::ControlSocket* BluetoothControl::_appInstance;
 
     /* virtual */ const string BluetoothControl::Initialize(PluginHost::IShell* service)
     {
@@ -46,12 +46,13 @@ namespace Plugin {
             result = Core::ToString(driverMessage);
         }
         else {
-            Data controllerData;
+            _appInstance = &_application;
             Bluetooth::ManagementSocket& administrator = _application.Control();
             Bluetooth::ManagementSocket::Devices(_adapters);
             administrator.DeviceId(_config.Interface.Value());
 
             _persistentStoragePath = _service->PersistentPath() + "Devices/";
+            Data controllerData;
             LoadController(_service->PersistentPath(), controllerData);
 
             if ((_config.PersistMAC.Value() == true) && 
@@ -164,8 +165,9 @@ namespace Plugin {
 
         // We bring the interface up, so we should bring it down as well..
         _application.Close();
-
         ::destruct_bluetooth_driver();
+
+        _appInstance = nullptr;
     }
 
     /* virtual */ string BluetoothControl::Information() const

--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -1613,7 +1613,7 @@ class BluetoothControl : public PluginHost::IPlugin
 
     public:
         inline static ControlSocket& Connector() {
-            return (_application);
+            return (*_appInstance);
         }
 
     private:
@@ -1672,7 +1672,8 @@ class BluetoothControl : public PluginHost::IPlugin
         std::list<DeviceImpl*> _devices;
         std::list<IBluetooth::INotification*> _observers;
         Config _config;
-        static ControlSocket _application;
+        ControlSocket _application;
+        static ControlSocket* _appInstance;
         string _persistentStoragePath;
     };
 

--- a/BluetoothControl/BluetoothControlJsonRpc.cpp
+++ b/BluetoothControl/BluetoothControlJsonRpc.cpp
@@ -184,7 +184,7 @@ namespace Plugin {
         uint32_t result = Core::ERROR_UNKNOWN_KEY;
 
         if (atoi(index.c_str()) == _btInterface) {
-            Bluetooth::ManagementSocket::Info info(_application.Control().Settings());
+            Bluetooth::ManagementSocket::Info info(_appInstance->Control().Settings());
             response.Interface = ("hci" + Core::ToString(_btInterface));
             response.Address = info.Address().ToString();
             response.Version = info.Version();

--- a/BluetoothControl/BluetoothControlJsonRpc.cpp
+++ b/BluetoothControl/BluetoothControlJsonRpc.cpp
@@ -184,7 +184,7 @@ namespace Plugin {
         uint32_t result = Core::ERROR_UNKNOWN_KEY;
 
         if (atoi(index.c_str()) == _btInterface) {
-            Bluetooth::ManagementSocket::Info info(_appInstance->Control().Settings());
+            Bluetooth::ManagementSocket::Info info(_application.Settings());
             response.Interface = ("hci" + Core::ToString(_btInterface));
             response.Address = info.Address().ToString();
             response.Version = info.Version();

--- a/TraceControl/TraceControl.h
+++ b/TraceControl/TraceControl.h
@@ -48,10 +48,6 @@ namespace Plugin {
         public:
             class Source : public Core::CyclicBuffer {
             private:
-                Source() = delete;
-                Source(const Source&) = delete;
-                Source& operator=(const Source&) = delete;
-
                 class LocalIterator : public Trace::ITraceIterator, public Trace::ITraceController {
                 private:
                     LocalIterator(const LocalIterator&) = delete;
@@ -118,8 +114,12 @@ namespace Plugin {
                 };
 
             public:
+                Source() = delete;
+                Source(const Source&) = delete;
+                Source& operator=(const Source&) = delete;
+
                 Source(const string& tracePath, RPC::IRemoteConnection* connection)
-                    : Core::CyclicBuffer(SourceName(tracePath, connection), 0, true)
+                    : Core::CyclicBuffer(SourceName(tracePath, connection), Core::File::USER_READ|Core::File::GROUP_READ|Core::File::CREATE|Core::File::SHAREABLE, 0, true)
                     , _iterator(connection == nullptr ? &_localIterator : nullptr)
                     , _control(connection == nullptr ? &_localIterator : nullptr)
                     , _connection(connection)
@@ -204,53 +204,61 @@ namespace Plugin {
 
                 state Load()
                 {
-                    uint32_t length;
+                    bool available = (IsValid() == false);
 
-                    // Traces will be commited in one go, First reserve, then write. So if there is a length (2 bytes)
-                    // The full trace has to be available as well.
-                    if ((_state == EMPTY) && ((length = Read(_traceBuffer, sizeof(_traceBuffer))) != 0)) {
+                    if (available == false) {
+                        available = Load();
+                    }
 
-                        if (length < 2) {
-                            // Didn't even get enough data to read entry size. This is impossible, fallback to failure.
-                            TRACE_L1("Inconsistent trace dump. Need to flush. %d", length);
-                            _state = FAILURE;
-                        } else {
-                            // TODO: This is platform dependend, needs to ba agnostic to the platform.
-                            uint16_t requiredLength = (_traceBuffer[1] << 8) | _traceBuffer[0];
+                    if (available == true) {
+                        uint32_t length;
 
-                            if (requiredLength != length) {
-                                // Something went wrong, didn't read a full entry.
+                        // Traces will be commited in one go, First reserve, then write. So if there is a length (2 bytes)
+                        // The full trace has to be available as well.
+                        if ((_state == EMPTY) && ((length = Read(_traceBuffer, sizeof(_traceBuffer))) != 0)) {
+
+                            if (length < 2) {
+                                // Didn't even get enough data to read entry size. This is impossible, fallback to failure.
+                                TRACE_L1("Inconsistent trace dump. Need to flush. %d", length);
                                 _state = FAILURE;
                             } else {
-                                // length(2 bytes) - clock ticks (8 bytes) - line number (4 bytes) - file/module/category/className
+                                // TODO: This is platform dependend, needs to ba agnostic to the platform.
+                                uint16_t requiredLength = (_traceBuffer[1] << 8) | _traceBuffer[0];
 
-                                // Keep track of location in buffer.
-                                uint32_t offset = /* length */ 2 /* clock */ + 8 /* Skip line number */ + 4;
+                                if (requiredLength != length) {
+                                    // Something went wrong, didn't read a full entry.
+                                    _state = FAILURE;
+                                } else {
+                                    // length(2 bytes) - clock ticks (8 bytes) - line number (4 bytes) - file/module/category/className
 
-                                // Skip file name.
-                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + offset)) + 1);
+                                    // Keep track of location in buffer.
+                                    uint32_t offset = /* length */ 2 /* clock */ + 8 /* Skip line number */ + 4;
 
-                                // Get module offset.
-                                _module = offset;
-                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _module)) + 1);
+                                    // Skip file name.
+                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + offset)) + 1);
 
-                                // Get category offset.
-                                _category = offset;
-                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _category)) + 1);
+                                    // Get module offset.
+                                    _module = offset;
+                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _module)) + 1);
 
-                                // Get class name offset.
-                                _classname = offset;
-                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _classname)) + 1);
+                                    // Get category offset.
+                                    _category = offset;
+                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _category)) + 1);
 
-                                ASSERT(length >= offset);
+                                    // Get class name offset.
+                                    _classname = offset;
+                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _classname)) + 1);
 
-                                // Rest of entry is information.
-                                _information = offset;
-                                _length = requiredLength - offset;
-                                _traceBuffer[requiredLength] = '\0';
+                                    ASSERT(length >= offset);
 
-                                // Entries are read in whole, so we are done.
-                                _state = LOADED;
+                                    // Rest of entry is information.
+                                    _information = offset;
+                                    _length = requiredLength - offset;
+                                    _traceBuffer[requiredLength] = '\0';
+
+                                    // Entries are read in whole, so we are done.
+                                    _state = LOADED;
+                                }
                             }
                         }
                     }

--- a/TraceControl/TraceControl.h
+++ b/TraceControl/TraceControl.h
@@ -48,6 +48,10 @@ namespace Plugin {
         public:
             class Source : public Core::CyclicBuffer {
             private:
+                Source() = delete;
+                Source(const Source&) = delete;
+                Source& operator=(const Source&) = delete;
+
                 class LocalIterator : public Trace::ITraceIterator, public Trace::ITraceController {
                 private:
                     LocalIterator(const LocalIterator&) = delete;
@@ -114,12 +118,8 @@ namespace Plugin {
                 };
 
             public:
-                Source() = delete;
-                Source(const Source&) = delete;
-                Source& operator=(const Source&) = delete;
-
                 Source(const string& tracePath, RPC::IRemoteConnection* connection)
-                    : Core::CyclicBuffer(SourceName(tracePath, connection), Core::File::USER_READ|Core::File::GROUP_READ|Core::File::CREATE|Core::File::SHAREABLE, 0, true)
+                    : Core::CyclicBuffer(SourceName(tracePath, connection), 0, true)
                     , _iterator(connection == nullptr ? &_localIterator : nullptr)
                     , _control(connection == nullptr ? &_localIterator : nullptr)
                     , _connection(connection)
@@ -204,61 +204,53 @@ namespace Plugin {
 
                 state Load()
                 {
-                    bool available = (IsValid() == false);
+                    uint32_t length;
 
-                    if (available == false) {
-                        available = Load();
-                    }
+                    // Traces will be commited in one go, First reserve, then write. So if there is a length (2 bytes)
+                    // The full trace has to be available as well.
+                    if ((_state == EMPTY) && ((length = Read(_traceBuffer, sizeof(_traceBuffer))) != 0)) {
 
-                    if (available == true) {
-                        uint32_t length;
+                        if (length < 2) {
+                            // Didn't even get enough data to read entry size. This is impossible, fallback to failure.
+                            TRACE_L1("Inconsistent trace dump. Need to flush. %d", length);
+                            _state = FAILURE;
+                        } else {
+                            // TODO: This is platform dependend, needs to ba agnostic to the platform.
+                            uint16_t requiredLength = (_traceBuffer[1] << 8) | _traceBuffer[0];
 
-                        // Traces will be commited in one go, First reserve, then write. So if there is a length (2 bytes)
-                        // The full trace has to be available as well.
-                        if ((_state == EMPTY) && ((length = Read(_traceBuffer, sizeof(_traceBuffer))) != 0)) {
-
-                            if (length < 2) {
-                                // Didn't even get enough data to read entry size. This is impossible, fallback to failure.
-                                TRACE_L1("Inconsistent trace dump. Need to flush. %d", length);
+                            if (requiredLength != length) {
+                                // Something went wrong, didn't read a full entry.
                                 _state = FAILURE;
                             } else {
-                                // TODO: This is platform dependend, needs to ba agnostic to the platform.
-                                uint16_t requiredLength = (_traceBuffer[1] << 8) | _traceBuffer[0];
+                                // length(2 bytes) - clock ticks (8 bytes) - line number (4 bytes) - file/module/category/className
 
-                                if (requiredLength != length) {
-                                    // Something went wrong, didn't read a full entry.
-                                    _state = FAILURE;
-                                } else {
-                                    // length(2 bytes) - clock ticks (8 bytes) - line number (4 bytes) - file/module/category/className
+                                // Keep track of location in buffer.
+                                uint32_t offset = /* length */ 2 /* clock */ + 8 /* Skip line number */ + 4;
 
-                                    // Keep track of location in buffer.
-                                    uint32_t offset = /* length */ 2 /* clock */ + 8 /* Skip line number */ + 4;
+                                // Skip file name.
+                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + offset)) + 1);
 
-                                    // Skip file name.
-                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + offset)) + 1);
+                                // Get module offset.
+                                _module = offset;
+                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _module)) + 1);
 
-                                    // Get module offset.
-                                    _module = offset;
-                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _module)) + 1);
+                                // Get category offset.
+                                _category = offset;
+                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _category)) + 1);
 
-                                    // Get category offset.
-                                    _category = offset;
-                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _category)) + 1);
+                                // Get class name offset.
+                                _classname = offset;
+                                offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _classname)) + 1);
 
-                                    // Get class name offset.
-                                    _classname = offset;
-                                    offset += static_cast<uint32_t>(strlen(reinterpret_cast<char*>(_traceBuffer + _classname)) + 1);
+                                ASSERT(length >= offset);
 
-                                    ASSERT(length >= offset);
+                                // Rest of entry is information.
+                                _information = offset;
+                                _length = requiredLength - offset;
+                                _traceBuffer[requiredLength] = '\0';
 
-                                    // Rest of entry is information.
-                                    _information = offset;
-                                    _length = requiredLength - offset;
-                                    _traceBuffer[requiredLength] = '\0';
-
-                                    // Entries are read in whole, so we are done.
-                                    _state = LOADED;
-                                }
+                                // Entries are read in whole, so we are done.
+                                _state = LOADED;
                             }
                         }
                     }


### PR DESCRIPTION
BluetoothControl plugin is creating a static instance of ControlSocket. Its parent class is Opening and Closing SynchronousChannelType from the Cosntructor and Destructor. During the Exit sequence the SynchronousChannelType::Close is invoking from the destruction sequence (as part of linux process stack cleanup). In this case the SocketPorts are already terminated as part of termination cleanups from the WPEFramework,  hence it is waiting on an infinite loop.

If we make this class to non static it will be removed from the stack during the deactivation of Plugin itself.