### PR TITLE
Compositor:Wayland: callsign search logic updated for Select

### DIFF
--- a/Compositor/Compositor.cpp
+++ b/Compositor/Compositor.cpp
@@ -563,7 +563,6 @@ namespace Plugin {
 
         uint32_t result = Core::ERROR_GENERAL;
 
-        Exchange::IInputSwitch* switcher;
         if (_inputSwitch) {
             result = _inputSwitch->Select(callsign);
         }

--- a/Compositor/lib/Wayland/Wayland.cpp
+++ b/Compositor/lib/Wayland/Wayland.cpp
@@ -414,13 +414,13 @@ namespace Plugin {
         {
             return (Core::ERROR_UNAVAILABLE);
         }
-        uint32_t Select(const string& name) override
+        uint32_t Select(const string& callsign) override
         {
             uint32_t status = Core::ERROR_UNAVAILABLE;
             std::list<Entry*>::iterator index(_clients.begin());
             while (index != _clients.end()) {
-                if (name == (*index)->Name()) {
-                    _server->SetInput(name.c_str());
+                if ((*index)->Name().find(callsign) == 0) {
+                    _server->SetInput((*index)->Name().c_str());
                     status = Core::ERROR_NONE;
                 }
                 index++;


### PR DESCRIPTION
In case of cobalt there is multiple surface for graphics and video. And these are prefixing by Callsign::layer: like Cobalt:graphics and Cobalt:video. But during the select application is sending only the callsign and hence the select will not work, since it could not able to find matching value.