### PR TITLE
Cobalt: suspend set only auto start is true

### DIFF
--- a/Cobalt/CobaltImplementation.cpp
+++ b/Cobalt/CobaltImplementation.cpp
@@ -205,8 +205,9 @@ public:
 
     virtual uint32_t Configure(PluginHost::IShell *service) {
         uint32_t result = _window.Configure(service);
-        _window.Suspend(true);
-        _state = PluginHost::IStateControl::SUSPENDED;
+        bool startSuspended = (service->AutoStart() == true);
+        _window.Suspend(startSuspended);
+        _state = (startSuspended ? PluginHost::IStateControl::SUSPENDED : PluginHost::IStateControl::RESUMED);
 
         return (result);
     }


### PR DESCRIPTION
Currently the Cobalt is starting always in suspended mode. This creating issue for DIALServer passive case. The DIAL is trying to activate Cobalt, but could not able to manage the app, since its in suspended state. So as like Netflix, better to keep the Cobalt in suspended mode only if it is starting with autostart as true. 