### PR TITLE
Development/netlink deadlock revert

### DIFF
--- a/NetworkControl/DHCPClientImplementation.h
+++ b/NetworkControl/DHCPClientImplementation.h
@@ -964,7 +964,7 @@ namespace Plugin {
                                 auto dispatch = Core::ProxyType<Core::IDispatch>(
                                     Core::ProxyType<FunctorDispatcher<std::function<void()>>>::Create(
                                         [this, copy]() {
-                                            this->_claimCallback(copy, false);
+                                            this->_claimCallback(copy, true);
                                         }
                                 ));
 

--- a/NetworkControl/DHCPClientImplementation.h
+++ b/NetworkControl/DHCPClientImplementation.h
@@ -25,17 +25,6 @@
 namespace WPEFramework {
 
 namespace Plugin {
-    template<typename T>
-    struct FunctorDispatcher : public Core::IDispatch, public T
-    {
-        FunctorDispatcher<T>(T&& x)
-            : T(x) {}
-
-        void Dispatch() override
-        {
-            T::operator()();
-        }
-    };
 
     class DHCPClientImplementation : public Core::SocketDatagram {
     public:
@@ -586,8 +575,8 @@ namespace Plugin {
 
         typedef Core::IteratorType<std::list<Offer>, Offer&, std::list<Offer>::iterator> Iterator;
         typedef Core::IteratorType<const std::list<Offer>, const Offer&, std::list<Offer>::const_iterator> ConstIterator;
-        typedef std::function<void(Offer)> DiscoverCallback;
-        typedef std::function<void(Offer, bool)> RequestCallback;
+        typedef std::function<void(Offer&)> DiscoverCallback;
+        typedef std::function<void(Offer&, bool)> RequestCallback;
 
     public:
         DHCPClientImplementation(const string& interfaceName, DiscoverCallback discoverCallback, RequestCallback claimCallback);
@@ -888,9 +877,7 @@ namespace Plugin {
             return (sizeof(CoreMessage) + index);
         }
 
-        /*  Parse a DHCP message and take appropiate action 
-            This will be called from ResourceMonitor thread
-        */
+        /* parse a DHCP message and take appropiate action */
         uint16_t ProcessMessage(const Core::NodeId& source, const uint8_t stream[], const uint16_t length)
         {
 
@@ -914,19 +901,7 @@ namespace Plugin {
                             if (xid == _discoverXID) {
                                 AddUnleasedOffer(Offer(source, frame, options));
                                 TRACE(Trace::Information, ("Received an Offer from: %s", source.HostAddress().c_str()));
-
-                                Offer& offer = _unleasedOffers.back();
-
-                                // Launch callback in another thread, so that we wont block ResourceManager
-                                auto x = Core::ProxyType<Core::IDispatch>(
-                                    Core::ProxyType<FunctorDispatcher<std::function<void()>>>::Create(
-                                        [this, offer]() {
-                                            this->_discoverCallback(offer);
-                                        }
-                                    ));
-
-                                Core::IWorkerPool::Instance().Submit(x);
-
+                                _discoverCallback(_unleasedOffers.back());
                             } else {
                                 TRACE_L1("Unknown XID encountered: %d", xid);
                             }
@@ -938,17 +913,9 @@ namespace Plugin {
                                         
                             if (offer.IsValid()) {
                                 offer.Current().Update(options); // Update if informations changed since offering
-                                Offer& leased = MakeLeased(offer.Current());
                                 
-                                // Launch callback in another thread, so that we wont block ResourceManager
-                                auto dispatch = Core::ProxyType<Core::IDispatch>(
-                                    Core::ProxyType<FunctorDispatcher<std::function<void()>>>::Create(
-                                        [this, leased]() {
-                                            this->_claimCallback(leased, true);
-                                        }
-                                ));
-
-                                Core::IWorkerPool::Instance().Submit(dispatch);
+                                Offer& leased = MakeLeased(offer.Current());
+                                _claimCallback(leased, true);
                             }
                             break;
                         }
@@ -960,18 +927,10 @@ namespace Plugin {
                                 Offer copy = offer.Current(); // we need a copy because of deletion
                                 RemoveUnleasedOffer(offer.Current());
 
-                                // Launch callback in another thread, so that we wont block ResourceManager
-                                auto dispatch = Core::ProxyType<Core::IDispatch>(
-                                    Core::ProxyType<FunctorDispatcher<std::function<void()>>>::Create(
-                                        [this, copy]() {
-                                            this->_claimCallback(copy, true);
-                                        }
-                                ));
-
-                                Core::IWorkerPool::Instance().Submit(dispatch);
+                                _claimCallback(copy, false);
                             }
                             break;
-                        }
+                        }                   
                 }
 
                 result = length;

--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -23,6 +23,7 @@ namespace WPEFramework {
 
 namespace Plugin
 {
+
     SERVICE_REGISTRATION(NetworkControl, 1, 0);
 
     static Core::ProxyPoolType<Web::Response> responseFactory(4);
@@ -434,13 +435,6 @@ namespace Plugin
             if (gateway.IsValid() == true) {
                 adapter.Gateway(Core::IPNode(Core::NodeId("0.0.0.0"), 0), gateway);
             }
-
-            // TODO: Currently not working because gateway is set in a wrong way
-            /*
-            if (broadcast.IsValid() == true) {
-                adapter.Broadcast(broadcast);
-            }
-            */
             
             Core::AdapterIterator::Flush();
 
@@ -529,7 +523,7 @@ namespace Plugin
 
                 if (entry != _dhcpInterfaces.end()) {
                     entry->second->StopWatchdog();
-                    entry->second->AcquireIP();
+                    entry->second->GetIP();
                     result = Core::ERROR_NONE;
                 }
             }
@@ -737,7 +731,7 @@ namespace Plugin
         if (entry != _dhcpInterfaces.end()) {
 
             // Lets try again!
-            entry->second->AcquireIP();
+            entry->second->GetIP();
         } else {
             TRACE_L1("Request denied for nonexisting network interface!");
         }

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -110,7 +110,7 @@ namespace Plugin {
 
     private:
         class AdapterObserver : public Core::IDispatch,
-                                public Core::AdapterObserver::INotification {
+                                public WPEFramework::Core::AdapterObserver::INotification {
         private:
             AdapterObserver() = delete;
             AdapterObserver(const AdapterObserver&) = delete;
@@ -138,10 +138,13 @@ namespace Plugin {
         public:
             void Open()
             {
+                _observer.Open();
             }
             void Close()
             {
                 Core::ProxyType<Core::IDispatch> job(*this);
+                _observer.Close();
+
                 _adminLock.Lock();
 
                 Core::IWorkerPool::Instance().Revoke(job);
@@ -347,12 +350,12 @@ namespace Plugin {
                 return (result);
             }
 
-            void AcquireIP() 
+            void GetIP() 
             {
-                return (AcquireIP(Core::NodeId()));
+                return (GetIP(Core::NodeId()));
             }
 
-            void AcquireIP(const Core::NodeId& preferred)
+            void GetIP(const Core::NodeId& preferred)
             {
 
                 auto offerIterator = _client.UnleasedOffers();


### PR DESCRIPTION
Reverting changes to Netlink, as it caused a deadlock when the network device was set up externally.
Synchronous flushing is done when the new network interface is set up, however, if blocks the ResourceMonitor thread, effectively blocking itself from getting a response. It needs to be rewritten in a fully asynchronous way before restoring changes.

As it is a critical problem on some platforms, revert is needed.
