### PR TITLE
DIALServer: Use Handler implementation only in master mode

### DIFF
--- a/DIALServer/DIALServer.cpp
+++ b/DIALServer/DIALServer.cpp
@@ -451,30 +451,30 @@ namespace Plugin {
                             response->Message = _T("Internal error");
                         }
                     } else {
-						if (result == Core::ERROR_NONE) {
+                        if (result == Core::ERROR_NONE) {
                             if (app.URL(parameters) == true) {
                                 response->Location = _dialServiceImpl->URL() + '/' + app.Name() + '/' + _DefaultControlExtension;
-								response->ErrorCode = Web::STATUS_CREATED;
-								response->Message = _T("Created");
-							}
-							else {
-								response->ErrorCode = Web::STATUS_NOT_IMPLEMENTED;
-								response->Message = _T("Not implemented");
-							}
-						}
-						else {
-							response->ErrorCode = Web::STATUS_SERVICE_UNAVAILABLE;
-							response->Message = _T("Service Unavailable");
-						}
+                                response->ErrorCode = Web::STATUS_CREATED;
+                                response->Message = _T("Created");
+                            }
+                            else {
+                                response->ErrorCode = Web::STATUS_NOT_IMPLEMENTED;
+                                response->Message = _T("Not implemented");
+                            }
+                        }
+                        else {
+                            response->ErrorCode = Web::STATUS_SERVICE_UNAVAILABLE;
+                            response->Message = _T("Service Unavailable");
+                        }
                     }
                 } else {
-					if (request.HasBody() == true) {
-						if (app.URL(parameters) == true) {
-							response->Location = _dialServiceImpl->URL() + '/' + app.Name() + '/' + _DefaultControlExtension;
-							response->ErrorCode = Web::STATUS_CREATED;
-							response->Message = _T("Created");
-						}
-						else {
+                    if (request.HasBody() == true) {
+                        if (app.URL(parameters) == true) {
+                            response->Location = _dialServiceImpl->URL() + '/' + app.Name() + '/' + _DefaultControlExtension;
+                            response->ErrorCode = Web::STATUS_CREATED;
+                            response->Message = _T("Created");
+                        }
+                        else {
                             response->ErrorCode = Web::STATUS_NOT_IMPLEMENTED;
                             response->Message = _T("Can not change the URL runtime");
                         }
@@ -643,8 +643,9 @@ namespace Plugin {
             }
         }
 
-        if (request.Origin.IsSet() == true)
+        if (request.Origin.IsSet() == true) {
             result->AccessControlOrigin = request.Origin.Value();
+        }
 
         TRACE(Protocol, (&(*result)));
         return (result);

--- a/DIALServer/DIALServer.h
+++ b/DIALServer/DIALServer.h
@@ -294,10 +294,8 @@ namespace Plugin {
                     _parent->event_start(_callsign, data);
                 } else {
                     if (_switchBoard != nullptr) {
-                        printf("%s:%s:%d -Switchboard Mode\n", __FILE__, __func__, __LINE__);
                         result = _switchBoard->Activate(_callsign);
                     } else {
-                        printf("%s:%s:%d -Active Mode\n", __FILE__, __func__, __LINE__);
                         result = _service->Activate(PluginHost::IShell::REQUESTED);
                     }
 
@@ -350,7 +348,6 @@ namespace Plugin {
                         result = true;
                     }
                     else {
-                        // Not implemented in Active mode
                         Exchange::IBrowser* browser = _service->QueryInterface<Exchange::IBrowser>();
 
                         if (browser != nullptr) {
@@ -528,7 +525,11 @@ namespace Plugin {
         public:
             virtual IApplication* Create(PluginHost::IShell* shell, const Config::App& config, DIALServer* parent)
             {
-                return (new HANDLER(shell, config, parent));
+                IApplication* application = nullptr;
+                if (config.Callsign.IsSet() == true) {
+                    return (new HANDLER(shell, config, parent));
+                }
+                return application;
             }
         };
         class EXTERNAL Protocol {


### PR DESCRIPTION
In slave mode, if the setting of url data to the application fails, it try it using the POST. But Currently in slave mode, we are registering the application handlers and all the url/data setting request to the app goes through the application handlers, and in slave mode the app instance will be always null and this sequence will never execute properly. 