### PR TITLE
DIALServer: add Network also the preconditions dependency

### DIFF
--- a/DIALServer/DIALServer.config
+++ b/DIALServer/DIALServer.config
@@ -1,6 +1,7 @@
 set(PLUGIN_DIALSERVER_AUTOSTART true CACHE STRING "Automatically start FirmwareControl plugin")
 set (autostart ${PLUGIN_DIALSERVER_AUTOSTART})
 set (preconditions Platform)
+set (preconditions Network)
 
 function(add_app config)
     set(oneValueArgs NAME CALLSIGN URL DATA)

--- a/DIALServer/DIALServer.config
+++ b/DIALServer/DIALServer.config
@@ -1,7 +1,6 @@
 set(PLUGIN_DIALSERVER_AUTOSTART true CACHE STRING "Automatically start FirmwareControl plugin")
 set (autostart ${PLUGIN_DIALSERVER_AUTOSTART})
-set (preconditions Platform)
-set (preconditions Network)
+set (preconditions Platform, Network)
 
 function(add_app config)
     set(oneValueArgs NAME CALLSIGN URL DATA)

--- a/DIALServer/DIALServer.cpp
+++ b/DIALServer/DIALServer.cpp
@@ -289,14 +289,13 @@ namespace Plugin {
             const uint8_t* rawId(Core::SystemInfo::Instance().RawDeviceId());
             const string deviceId(Core::SystemInfo::Instance().Id(rawId, ~0));
 
-            Core::NodeId source((_config.Interface.Value().empty() == true) || (selectedNode.IsValid() == false) ? selectedNode.AnyInterface() : selectedNode);
-
             _dialURL = Core::URL(service->Accessor());
+            _dialURL.Host(selectedNode.HostAddress());
             _dialPath = '/' + _dialURL.Path().Value();
 
             // TODO: THis used to be the MAC, but I think  it is just a unique number, otherwise, we need the MAC
             //       that goes with the selectedNode !!!!
-            _dialServiceImpl = new DIALServerImpl(deviceId, service->Accessor(), _DefaultAppInfoPath);
+            _dialServiceImpl = new DIALServerImpl(deviceId, _dialURL.Text(), _DefaultAppInfoPath);
 
             ASSERT(_dialServiceImpl != nullptr);
 


### PR DESCRIPTION
The value of accessor host address is some time 0.0.0.0 or invalid, since these are getting prior to the NetworkControl up. So in this case the dialURL will be created using 0.0.0.0 host address and will not work. So start DIAL only once the Network interface up and ready and use the selected Host address to create dialURL