### PR TITLE
[Power] HP40A-126: boot up from power loss to last mode

### DIFF
--- a/Power/CMakeLists.txt
+++ b/Power/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories( ${MODULE_NAME}
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 find_package(BcmPowerManager QUIET)
+find_package(MFRBootenvlibs QUIET)
 
 if(BCM_PM_FOUND)
     find_package(NEXUS REQUIRED)
@@ -70,6 +71,11 @@ if(BCM_PM_FOUND)
 else()
     message("Configuring for ${PLUGIN_POWER_IMPLEMENTATION}....")
     target_sources(${MODULE_NAME} PRIVATE PowerImplementation/${PLUGIN_POWER_IMPLEMENTATION}/PowerImplementation.cpp)
+    if(MFRBOOTENVLIBS_FOUND)
+        message("Found MFRBootenvlibs....Enabling Special features...")
+        add_definitions(-DMFRBOOTENVLIBS_FOUND=1)
+        target_link_libraries(${MODULE_NAME} PRIVATE ${MFRBOOTENVLIBS_LIBRARIES})
+    endif()
 endif()
 
 target_link_libraries(${MODULE_NAME}

--- a/Power/PowerImplementation/Linux/PowerImplementation.cpp
+++ b/Power/PowerImplementation/Linux/PowerImplementation.cpp
@@ -235,9 +235,9 @@ private:
                 Notify(state);
                 _currentState = state;
 		if (Exchange::IPower::PCState::PowerOff != state) {
-		    /* No need to store PowerOff for resuming to after powerloss. */
-		    updatePowerModeForPowerlossBoot(state);
-		    sync();
+			/* No need to store PowerOff for resuming to after powerloss. */
+			updatePowerModeForPowerlossBoot(state);
+			sync();
 		}
 
                 switch (state) {
@@ -246,8 +246,6 @@ private:
                     case Exchange::IPower::PCState::PassiveStandby:
                     case Exchange::IPower::PCState::SuspendToRAM:
                         {
-                            updatePowerModeForPowerlossBoot(state);
-                            sync();
                             ::write(_triggerFile, "1", 1);
                             /* We will be able to write state only if we are in 'On' State. */
                             ::write(_stateFile, newMode->label, newMode->length);

--- a/Power/PowerImplementation/Linux/PowerImplementation.cpp
+++ b/Power/PowerImplementation/Linux/PowerImplementation.cpp
@@ -123,8 +123,8 @@ public:
             }
         }
 
-        /* Add POWEROFF since its software implementation. */
-        _supportedModes |= (1 << Exchange::IPower::PCState::PowerOff);
+        /* Add ON & POWEROFF since its software implementation. */
+        _supportedModes |= ((1 << Exchange::IPower::PCState::PowerOff) | (1 << Exchange::IPower::PCState::On));
         TRACE(Trace::Information, (_T("SupportedModes : %d"), _supportedModes));
 
         _stateFile = ::open(StateFile, O_WRONLY);

--- a/cmake/FindMFRBootenvlibs.cmake
+++ b/cmake/FindMFRBootenvlibs.cmake
@@ -4,28 +4,22 @@
 #  MFRBOOTENVLIBS_INCLUDE_DIRS - The bootenvlibs include directories
 #  MFRBOOTENVLIBS_LIBRARIES - The libraries needed to use bootenvlibs
 #
-# Copyright (C) 2019 RDK.
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 1.  Redistributions of source code must retain the above copyright
-#     notice, this list of conditions and the following disclaimer.
-# 2.  Redistributions in binary form must reproduce the above copyright
-#     notice, this list of conditions and the following disclaimer in the
-#     documentation and/or other materials provided with the distribution.
+# Copyright 2020 RDK Management
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
-# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 find_package(PkgConfig)
 pkg_check_modules(MFRBOOTENVLIBS libbootenv)

--- a/cmake/FindMFRBootenvlibs.cmake
+++ b/cmake/FindMFRBootenvlibs.cmake
@@ -1,0 +1,51 @@
+# - Try to find MFRBOOTENVLIBS
+# Once done this will define
+#  MFRBOOTENVLIBS_FOUND - System has bootenvlibs
+#  MFRBOOTENVLIBS_INCLUDE_DIRS - The bootenvlibs include directories
+#  MFRBOOTENVLIBS_LIBRARIES - The libraries needed to use bootenvlibs
+#
+# Copyright (C) 2019 RDK.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+find_package(PkgConfig)
+pkg_check_modules(MFRBOOTENVLIBS libbootenv)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(bootenvlibs DEFAULT_MSG MFRBOOTENVLIBS_LIBRARIES)
+
+mark_as_advanced(MFRBOOTENVLIBS_INCLUDE_DIRS MFRBOOTENVLIBS_LIBRARIES)
+
+
+find_library(MFRBOOTENVLIBS_LIBRARY NAMES ${MFRBOOTENVLIBS_LIBRARIES}
+    HINTS ${MFRBOOTENVLIBS_LIBDIR} ${MFRBOOTENVLIBS_LIBRARY_DIRS}
+    )
+
+if(MFRBOOTENVLIBS_LIBRARY AND NOT TARGET bootenvlibs::bootenvlibs)
+    add_library(bootenvlibs::bootenvlibs UNKNOWN IMPORTED)
+    set_target_properties(bootenvlibs::bootenvlibs PROPERTIES
+        IMPORTED_LOCATION "${MFRBOOTENVLIBS_LIBRARY}"
+        INTERFACE_LINK_LIBRARIES "${MFRBOOTENVLIBS_LIBRARIES}"
+        INTERFACE_COMPILE_OPTIONS "${MFRBOOTENVLIBS_DEFINITIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${MFRBOOTENVLIBS_INCLUDE_DIRS}"
+        )
+endif()

--- a/cmake/FindMFRBootenvlibs.cmake
+++ b/cmake/FindMFRBootenvlibs.cmake
@@ -1,9 +1,3 @@
-# - Try to find MFRBOOTENVLIBS
-# Once done this will define
-#  MFRBOOTENVLIBS_FOUND - System has bootenvlibs
-#  MFRBOOTENVLIBS_INCLUDE_DIRS - The bootenvlibs include directories
-#  MFRBOOTENVLIBS_LIBRARIES - The libraries needed to use bootenvlibs
-#
 # If not stated otherwise in this file or this component's license file the
 # following copyright and licenses apply:
 #
@@ -20,6 +14,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# - Try to find MFRBOOTENVLIBS
+# Once done this will define
+#  MFRBOOTENVLIBS_FOUND - System has bootenvlibs
+#  MFRBOOTENVLIBS_INCLUDE_DIRS - The bootenvlibs include directories
+#  MFRBOOTENVLIBS_LIBRARIES - The libraries needed to use bootenvlibs
 
 find_package(PkgConfig)
 pkg_check_modules(MFRBOOTENVLIBS libbootenv)


### PR DESCRIPTION
Reason for change: Added logic to store lastpowermode in uboot environment variable so that device can boot to last power state when powerloss recovery happens when in that state.
Test Procedure: Build complete image and test Power plugin.
Risks: Medium.

Signed-off-by: Arun P Madhavan <arun_madhavan@comcast.com>