### PR TITLE
[Networking] WebServer dependency changes

### DIFF
--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -217,6 +217,18 @@ namespace Plugin
         // From now on we observer the states of the give interfaces.
         _observer->Open();
 
+        PluginHost::ISubSystem* subSystem = _service->SubSystems();
+
+        ASSERT(subSystem != nullptr);
+
+        if (subSystem != nullptr) {
+            if ((subSystem->IsActive(PluginHost::ISubSystem::NETWORK) == false)) {
+                subSystem->Set(PluginHost::ISubSystem::NETWORK, nullptr);
+            }
+
+            subSystem->Release();
+        }            
+
         // On success return empty, to indicate there is no error text.
         return (result);
     }
@@ -413,17 +425,6 @@ namespace Plugin
                 }
             }
 
-            PluginHost::ISubSystem* subSystem = _service->SubSystems();
-
-            ASSERT(subSystem != nullptr);
-
-            if (subSystem != nullptr) {
-                if ((subSystem->IsActive(PluginHost::ISubSystem::NETWORK) == false) && (ipAddress.IsLocalInterface() == false)) {
-                    subSystem->Set(PluginHost::ISubSystem::NETWORK, nullptr);
-                }
-
-                subSystem->Release();
-            }            
 
             if (addIt == true) {
                 TRACE_L1("Setting IP: %s", ipAddress.HostAddress().c_str());

--- a/WebKitBrowser/UX.config
+++ b/WebKitBrowser/UX.config
@@ -1,6 +1,6 @@
 set (autostart ${PLUGIN_UX_AUTOSTART})
 
-set(preconditions Graphics)
+set(preconditions Graphics WebSource )
 
 map()
     kv(outofprocess true)

--- a/WebServer/WebServer.config
+++ b/WebServer/WebServer.config
@@ -1,6 +1,8 @@
 set (autostart true)
 set (resumed true)
 
+set(preconditions Network )
+
 map()
     key(root)
     map()


### PR DESCRIPTION
This should fix Splashscreen sometimes failing due to race with network initialization.

Changes:
1. WebServer now depends on Network to be available and UX depends on WebServer.
2. Network precondition is now set whenever all defined interfaces are UP. Previously it 
   was set when the first IP was assigned to any of the interfaces. That could lead to
   ambiguous behaviour and having IP is not critical indicator if network is ready
   (eg. when depending on wifi that has not yet connected to any network)