### PR TITLE
WebServer: Makes file server configurable

### DIFF
--- a/WebServer/WebServer.config
+++ b/WebServer/WebServer.config
@@ -1,6 +1,7 @@
 option(PLUGIN_WEBSERVER_PROXY_DEVICEINFO "Enable proxy for DeviceInfo" ${PLUGIN_DEVICEINFO})
 option(PLUGIN_WEBSERVER_PROXY_DIALSERVER "Enable proxy for DIALServer" ${PLUGIN_DIALSERVER})
 
+set(PLUGIN_WEBSERVER_ENABLE_FILE_SERVER true CACHE STRING "Enable file server")
 set (autostart true)
 set (resumed true)
 
@@ -12,6 +13,7 @@ map()
     kv(port ${PLUGIN_WEBSERVER_PORT})
     kv(binding "0.0.0.0")
     kv(path ${PLUGIN_WEBSERVER_PATH})
+    kv(servefile ${PLUGIN_WEBSERVER_ENABLE_FILE_SERVER})
     kv(proxies ___array___)
 end()
 ans(configuration)


### PR DESCRIPTION
This commit is for making the file serving feature configurable.
This is needed since, in cases we only wants the WebServer to be a
proxy for another plugin, we don't want to exposes the filesystem
contents to external world. In such case, we could use this to disable
the file serving feature.
With this change, we would be able to configure WebServer only as a
proxy server.