### PR TITLE
FirmwareControl: Change to update download progress to the initiated process

### DIFF
--- a/FirmwareControl/FirmwareControl.cpp
+++ b/FirmwareControl/FirmwareControl.cpp
@@ -131,6 +131,7 @@ namespace Plugin {
         if ((status == Core::ERROR_NONE) || (status == Core::ERROR_INPROGRESS)) {
 
             Status(UpgradeStatus::DOWNLOAD_STARTED, ErrorType::ERROR_NONE, 0);
+            downloadEngine.StartProgressNotifier(_interval);
             status = WaitForCompletion(_waitTime);
             if ((status == Core::ERROR_NONE) && (DownloadStatus() == Core::ERROR_NONE)) {
                  Status(UpgradeStatus::DOWNLOAD_COMPLETED, ErrorType::ERROR_NONE, 0);

--- a/FirmwareControl/FirmwareControl.cpp
+++ b/FirmwareControl/FirmwareControl.cpp
@@ -134,11 +134,15 @@ namespace Plugin {
             downloadEngine.StartProgressNotifier(_interval);
             status = WaitForCompletion(_waitTime);
             if ((status == Core::ERROR_NONE) && (DownloadStatus() == Core::ERROR_NONE)) {
-                 Status(UpgradeStatus::DOWNLOAD_COMPLETED, ErrorType::ERROR_NONE, 0);
-            } else {
-                status = ((status != Core::ERROR_NONE)? status: DownloadStatus());
-                Status(UpgradeStatus::DOWNLOAD_ABORTED, status, 0);
+                 if (_hash.empty() != true) {
+                     status = downloadEngine.CheckHMAC();
+                 }
             }
+        }
+
+        status = ((status != Core::ERROR_NONE)? status: DownloadStatus());
+        if (status == Core::ERROR_NONE) {
+            Status(UpgradeStatus::DOWNLOAD_COMPLETED, ErrorType::ERROR_NONE, 100);
         } else {
             Status(UpgradeStatus::DOWNLOAD_ABORTED, status, 0);
         }

--- a/FirmwareControl/FirmwareControl.cpp
+++ b/FirmwareControl/FirmwareControl.cpp
@@ -131,7 +131,7 @@ namespace Plugin {
         if ((status == Core::ERROR_NONE) || (status == Core::ERROR_INPROGRESS)) {
 
             Status(UpgradeStatus::DOWNLOAD_STARTED, ErrorType::ERROR_NONE, 0);
-            status = WaitForCompletion(_waitTime);
+            status = WaitForCompletion(_waitTime * 1000);
         }
 
         status = ((status != Core::ERROR_NONE)? status: DownloadStatus());

--- a/FirmwareControl/FirmwareControl.cpp
+++ b/FirmwareControl/FirmwareControl.cpp
@@ -125,9 +125,9 @@ namespace Plugin {
         TRACE(Trace::Information, (string(__FUNCTION__)));
         Notifier notifier(this);
 
-        PluginHost::DownloadEngine downloadEngine(&notifier, _destination + Name, _interval);
+        PluginHost::DownloadEngine downloadEngine(&notifier, "", _interval);
 
-        uint32_t status = downloadEngine.Start(_source, _destination, _hash);
+        uint32_t status = downloadEngine.Start(_source, _destination + Name, _hash);
         if ((status == Core::ERROR_NONE) || (status == Core::ERROR_INPROGRESS)) {
 
             Status(UpgradeStatus::DOWNLOAD_STARTED, ErrorType::ERROR_NONE, 0);

--- a/FirmwareControl/FirmwareControl.cpp
+++ b/FirmwareControl/FirmwareControl.cpp
@@ -125,19 +125,13 @@ namespace Plugin {
         TRACE(Trace::Information, (string(__FUNCTION__)));
         Notifier notifier(this);
 
-        PluginHost::DownloadEngine downloadEngine(&notifier, _destination + Name);
+        PluginHost::DownloadEngine downloadEngine(&notifier, _destination + Name, _interval);
 
         uint32_t status = downloadEngine.Start(_source, _destination, _hash);
         if ((status == Core::ERROR_NONE) || (status == Core::ERROR_INPROGRESS)) {
 
             Status(UpgradeStatus::DOWNLOAD_STARTED, ErrorType::ERROR_NONE, 0);
-            downloadEngine.StartProgressNotifier(_interval);
             status = WaitForCompletion(_waitTime);
-            if ((status == Core::ERROR_NONE) && (DownloadStatus() == Core::ERROR_NONE)) {
-                 if (_hash.empty() != true) {
-                     status = downloadEngine.CheckHMAC();
-                 }
-            }
         }
 
         status = ((status != Core::ERROR_NONE)? status: DownloadStatus());

--- a/FirmwareControl/FirmwareControl.h
+++ b/FirmwareControl/FirmwareControl.h
@@ -116,7 +116,7 @@ namespace Plugin {
             }
             virtual void NotifyProgress(const uint8_t percentage) override
             {
-                _parent.NotifyProgress(UpgradeStatus::DOWNLOAD_STARTED, Core::ERROR_NONE, percentage);
+                _parent.NotifyProgress(UpgradeStatus::DOWNLOAD_STARTED, ErrorType::ERROR_NONE, percentage);
             }
 
         private:

--- a/FirmwareControl/FirmwareControl.h
+++ b/FirmwareControl/FirmwareControl.h
@@ -110,9 +110,13 @@ namespace Plugin {
             virtual ~Notifier()
             {
             }
-            virtual void NotifyDownloadStatus(const uint32_t status) override
+            virtual void NotifyStatus(const uint32_t status) override
             {
                 _parent.NotifyDownloadStatus(status);
+            }
+            virtual void NotifyProgress(const uint8_t percentage) override
+            {
+                _parent.NotifyProgress(UpgradeStatus::DOWNLOAD_STARTED, Core::ERROR_NONE, percentage);
             }
 
         private:
@@ -209,11 +213,11 @@ namespace Plugin {
             ASSERT(control != nullptr);
 
             if (control != nullptr) {
-               control->NotifyInstallProgress(mfrStatus);
+               control->NotifyInstallStatus(mfrStatus);
             }
         }
 
-        inline void NotifyInstallProgress(mfrUpgradeStatus_t mfrStatus)
+        inline void NotifyInstallStatus(mfrUpgradeStatus_t mfrStatus)
         {
             UpgradeStatus upgradeStatus = ConvertMfrWriteStatusToUpgradeStatus(mfrStatus.progress);
             if ((upgradeStatus == UPGRADE_COMPLETED) || (upgradeStatus == INSTALL_ABORTED)) {
@@ -227,7 +231,7 @@ namespace Plugin {
             }
         }
 
-        inline void NotifyProgress(const UpgradeStatus& upgradeStatus, const ErrorType& errorType, const uint16_t& percentage)
+        inline void NotifyProgress(const UpgradeStatus& upgradeStatus, const ErrorType& errorType, const uint8_t& percentage)
         {
             if ((upgradeStatus == UPGRADE_COMPLETED) ||
                 (upgradeStatus == INSTALL_ABORTED) ||
@@ -255,7 +259,7 @@ namespace Plugin {
         uint32_t endpoint_upgrade(const JsonData::FirmwareControl::UpgradeParamsData& params);
         uint32_t get_status(Core::JSON::EnumType<JsonData::FirmwareControl::StatusType>& response) const;
         void event_upgradeprogress(const JsonData::FirmwareControl::StatusType& status,
-                                   const JsonData::FirmwareControl::UpgradeprogressParamsData::ErrorType& error, const uint16_t& percentage);
+                                   const JsonData::FirmwareControl::UpgradeprogressParamsData::ErrorType& error, const uint8_t& percentage);
 
         inline uint32_t WaitForCompletion(int32_t waitTime)
         {
@@ -295,7 +299,7 @@ namespace Plugin {
             return status;
         }
 
-        inline void Status(const UpgradeStatus& upgradeStatus, const uint32_t& error, const uint16_t& percentage)
+        inline void Status(const UpgradeStatus& upgradeStatus, const uint32_t& error, const uint8_t& percentage)
         {
             _adminLock.Lock();
             _upgradeStatus = upgradeStatus;

--- a/FirmwareControl/FirmwareControl.h
+++ b/FirmwareControl/FirmwareControl.h
@@ -62,6 +62,7 @@ namespace Plugin {
             INVALID_STATES,
             OPERATION_NOT_PERMITTED,
             INCORRECT_HASH,
+            UNAUTHENTICATED,
             UNAVAILABLE,
             TIMEDOUT,
             UNKNOWN
@@ -321,6 +322,9 @@ namespace Plugin {
                 break;
             case Core::ERROR_INCORRECT_HASH:
                 errorType = ErrorType::INCORRECT_HASH;
+                break;
+            case Core::ERROR_UNAUTHENTICATED:
+                errorType = ErrorType::UNAUTHENTICATED;
                 break;
             case Core::ERROR_TIMEDOUT:
                 errorType = ErrorType::TIMEDOUT;

--- a/FirmwareControl/FirmwareControlJsonRpc.cpp
+++ b/FirmwareControl/FirmwareControlJsonRpc.cpp
@@ -136,7 +136,7 @@ namespace Plugin {
     }
 
     // Event: upgradeprogress - Notifies progress of upgrade
-    void FirmwareControl::event_upgradeprogress(const StatusType& status, const UpgradeprogressParamsData::ErrorType& error, const uint16_t& percentage)
+    void FirmwareControl::event_upgradeprogress(const StatusType& status, const UpgradeprogressParamsData::ErrorType& error, const uint8_t& percentage)
     {
         UpgradeprogressParamsData params;
         params.Status = status;

--- a/FirmwareControl/doc/FirmwareControlPlugin.md
+++ b/FirmwareControl/doc/FirmwareControlPlugin.md
@@ -103,7 +103,7 @@ Also see: [upgradeprogress](#event.upgradeprogress)
 | params.name | string | name of the firmware |
 | params?.location | string | <sup>*(optional)*</sup> location/url of the firmware to be upgraded |
 | params?.type | string | <sup>*(optional)*</sup> type of the firmware (must be one of the following: *CDL*, *RCDL*) |
-| params?.progressinterval | number | <sup>*(optional)*</sup> number of seconds between progress update events (5 secoonds, 10 seconds etc). 0 means invoking callback only once to report final upgrade result |
+| params?.progressinterval | number | <sup>*(optional)*</sup> number of seconds between progress update events (5 seconds, 10 seconds etc). 0 means invoking callback only once to report final upgrade result |
 | params?.hmac | string | <sup>*(optional)*</sup> HMAC value of firmare |
 
 ### Result

--- a/FirmwareControl/doc/FirmwareControlPlugin.md
+++ b/FirmwareControl/doc/FirmwareControlPlugin.md
@@ -123,6 +123,7 @@ Also see: [upgradeprogress](#event.upgradeprogress)
 | 22 | ```ERROR_UNKNOWN_KEY``` | Bad hash value given |
 | 5 | ```ERROR_ILLEGAL_STATE``` | Invalid state of device |
 | 14 | ```ERROR_INCORRECT_HASH``` | Incorrect hash given |
+| 42 | ```ERROR_UNAUTHENTICATED``` | Authenitcation failed |
 
 ### Example
 
@@ -221,7 +222,7 @@ Notifies progress of upgrade.
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.status | string | upgrade status (must be one of the following: *none*, *upgradestarted*, *downloadstarted*, *downloadaborted*, *downloadcompleted*, *installnotstarted*, *installaborted*, *installstarted*, *upgradecompleted*, *upgradecancelled*) |
-| params.error | string | reason of error (must be one of the following: *none*, *generic*, *invalidparameters*, *invalidstate*, *operationotsupported*, *incorrecthash*, *unavailable*, *timedout*, *unkown*) |
+| params.error | string | reason of error (must be one of the following: *none*, *generic*, *invalidparameters*, *invalidstate*, *operationotsupported*, *incorrecthash*, *unautheticated*, *unavailable*, *timedout*, *unkown*) |
 | params.percentage | number |  |
 
 ### Example


### PR DESCRIPTION
1. Changes to update download progress
2. Moved Hash value comparison logic to the FirmwareControl context, instead handling it from the webtransfer context (it helps to avoid delay in the json event notification during the Hash comparison)