### PR TITLE
[Power] Persisted state not updated when resumed from STR

### DIFF
--- a/Power/Power.cpp
+++ b/Power/Power.cpp
@@ -240,6 +240,9 @@ namespace Plugin {
         }
 
         _adminLock.Unlock();
+
+        /* May be resuming from another power state; lets update persisted state. */
+        power_set_persisted_state(state);
     }
     void Power::PowerKey() /* override */ {
         if (power_get_state() == Exchange::IPower::PCState::On) {


### PR DESCRIPTION
Issue: When HP40A device is put to STR and triggered Wake-Up, wake up sequence is not coming via Power plugin which results in not updating the persisted state.
Reason for change: Added persisted state update logic in power state change callback so that even hardware triggered state also gets updated.
Test Procedure: Put (HP40A)DUT in STR and trigger RCU/WoL wake-up, let device to be in ON state for few minutes. Then power cycle device. It shall boot to ON(last state); not to STR.
Risks: Low.

Signed-off-by: Arun P Madhavan <arun_madhavan@comcast.com>