### PR TITLE
[RemoteControl] Add mising return statement for LoadModule in GreenPeak

### DIFF
--- a/RemoteControl/GreenPeak.cpp
+++ b/RemoteControl/GreenPeak.cpp
@@ -81,6 +81,8 @@ namespace Plugin {
             }
             ::free(image);
         }
+
+        return result;
     }
 
     static uint32_t UnloadModule(const string& moduleName)


### PR DESCRIPTION
This patch adds the missing return statement for LoadModule method.

The return statement was missing from this method and was thus returning
Junk values to the caller.

Most of the time we got `Core::ERROR_NONE/0` as the return so the code
worked.

If we get a junk value which is not 0. The GreenPeak producer will not
work.

Signed-off-by: harikrishnan.p <harikrishnan.p@tataelxsi.co.in>