### PR TITLE
[CLEANUP] Followup of the Module/rework cleanup on Thunder.

### DIFF
--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -717,7 +717,7 @@ class BluetoothControl : public PluginHost::IPlugin
         }; // class Data
 
     public:
-        class EXTERNAL DeviceImpl : public Exchange::IBluetooth::IDevice {
+        class DeviceImpl : public Exchange::IBluetooth::IDevice {
         private:
             static constexpr uint16_t ACTION_MASK = 0x00FF;
 
@@ -1576,7 +1576,7 @@ class BluetoothControl : public PluginHost::IPlugin
         }; // class DeviceImpl
 
     public:
-        class EXTERNAL DeviceRegular : public DeviceImpl, public Exchange::IBluetooth::IClassic {
+        class DeviceRegular : public DeviceImpl, public Exchange::IBluetooth::IClassic {
         public:
             DeviceRegular() = delete;
             DeviceRegular(const DeviceRegular&) = delete;
@@ -1803,7 +1803,7 @@ class BluetoothControl : public PluginHost::IPlugin
         }; // class DeviceRegular
 
     public:
-        class EXTERNAL DeviceLowEnergy : public DeviceImpl, public Exchange::IBluetooth::ILowEnergy {
+        class DeviceLowEnergy : public DeviceImpl, public Exchange::IBluetooth::ILowEnergy {
         public:
             DeviceLowEnergy() = delete;
             DeviceLowEnergy(const DeviceLowEnergy&) = delete;
@@ -1964,9 +1964,9 @@ class BluetoothControl : public PluginHost::IPlugin
         }; // class DeviceLowEnergy
 
     public:
-        class EXTERNAL Status : public Core::JSON::Container {
+        class Status : public Core::JSON::Container {
         public:
-            class EXTERNAL Property : public Core::JSON::Container {
+            class Property : public Core::JSON::Container {
             public:
                 Property& operator=(const Property&) = delete;
                 Property()

--- a/BluetoothRemoteControl/T4HDecoders.cpp
+++ b/BluetoothRemoteControl/T4HDecoders.cpp
@@ -23,7 +23,7 @@ namespace WPEFramework {
 
 namespace Decoders {
 
-class EXTERNAL ADPCM : public IDecoder {
+class ADPCM : public IDecoder {
 private:
     const uint8_t  WindowSize = 32;
 
@@ -129,7 +129,7 @@ public:
 
 static DecoderFactory<ADPCM> _adpcmFactory;
 
-class EXTERNAL PCM : public IDecoder {
+class PCM : public IDecoder {
 private:
     const uint8_t  WindowSize = 32;
 

--- a/BluetoothRemoteControl/WAVRecorder.h
+++ b/BluetoothRemoteControl/WAVRecorder.h
@@ -25,7 +25,7 @@ namespace WPEFramework {
 
 namespace WAV {
 
-class EXTERNAL Recorder {
+class Recorder {
 public:
     enum codec {
         PCM = 1,

--- a/DHCPServer/DHCPServerImplementation.h
+++ b/DHCPServer/DHCPServerImplementation.h
@@ -111,7 +111,7 @@ namespace Plugin {
 
 #pragma pack(pop)
 
-        class EXTERNAL Flow {
+        class Flow {
         private:
             Flow(const Flow& a_Copy) = delete;
             Flow& operator=(const Flow& a_RHS) = delete;

--- a/DIALServer/DIALServer.h
+++ b/DIALServer/DIALServer.h
@@ -532,7 +532,7 @@ namespace Plugin {
                 return application;
             }
         };
-        class EXTERNAL Protocol {
+        class Protocol {
         private:
             // -------------------------------------------------------------------
             // This object should not be copied or assigned. Prevent the copy

--- a/DisplayInfo/DisplayInfoTracing.h
+++ b/DisplayInfo/DisplayInfoTracing.h
@@ -24,7 +24,7 @@
 namespace WPEFramework {
 namespace Plugin {
 
-    class EXTERNAL HDCPDetailedInfo {
+    class HDCPDetailedInfo {
     public:
         // -------------------------------------------------------------------
         // This object should not be copied or assigned. Prevent the copy

--- a/IOConnector/IOConnector.cpp
+++ b/IOConnector/IOConnector.cpp
@@ -41,7 +41,7 @@ namespace Plugin
 
     static Core::ProxyPoolType<Web::JSONBodyType<IOConnector::Data>> jsonBodyDataFactory(1);
 
-    class EXTERNAL IOState {
+    class IOState {
     private:
         // -------------------------------------------------------------------
         // This object should not be copied or assigned. Prevent the copy

--- a/LocationSync/LocationService.h
+++ b/LocationSync/LocationService.h
@@ -28,7 +28,7 @@ namespace Plugin {
 
     struct IGeography;
 
-    class EXTERNAL LocationService
+    class LocationService
         : public PluginHost::ISubSystem::ILocation,
           public PluginHost::ISubSystem::IInternet,
           public Web::WebLinkType<Core::SocketStream, Web::Response, Web::Request, Core::ProxyPoolType<Web::Response>&> {

--- a/NetworkControl/DHCPClientImplementation.h
+++ b/NetworkControl/DHCPClientImplementation.h
@@ -115,7 +115,7 @@ namespace Plugin {
         };
 #pragma pack(pop)
 
-        class EXTERNAL Flow {
+        class Flow {
         private:
             Flow(const Flow& a_Copy) = delete;
             Flow& operator=(const Flow& a_RHS) = delete;

--- a/OpenCDMi/CENCParser.h
+++ b/OpenCDMi/CENCParser.h
@@ -21,7 +21,6 @@
 #define __CENCPARSER_H
 
 #include "Module.h"
-#include <ocdm/IOCDM.h>
 
 namespace WPEFramework {
 namespace Plugin {

--- a/OpenCDMi/FrameworkRPC.cpp
+++ b/OpenCDMi/FrameworkRPC.cpp
@@ -22,21 +22,12 @@
 #include <vector>
 
 #include "Module.h"
+#include "CENCParser.h"
 
 // Get in the definitions required for access to the sepcific
 // DRM engines.
 #include <interfaces/IDRM.h>
-
-// Get in the definitions required for access to the OCDM
-// counter part living in the applications
-#include <ocdm/DataExchange.h>
-#include <ocdm/IOCDM.h>
-
 #include <interfaces/IContentDecryption.h>
-
-#include "CENCParser.h"
-
-#include <ocdm/open_cdm.h>
 
 extern "C" {
 

--- a/OpenCDMi/Module.h
+++ b/OpenCDMi/Module.h
@@ -26,6 +26,11 @@
 
 #include <plugins/plugins.h>
 
+// Get in the definitions required for access to the OCDM
+// counter part living in the applications
+#include <ocdm/IOCDM.h>
+#include <ocdm/open_cdm.h>
+
 #undef EXTERNAL
 #define EXTERNAL
 

--- a/OpenCDMi/OCDM.cpp
+++ b/OpenCDMi/OCDM.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "OCDM.h"
-#include <ocdm/open_cdm.h>
 #include <interfaces/IDRM.h>
 
 namespace WPEFramework {

--- a/Packager/PackagerImplementation.h
+++ b/Packager/PackagerImplementation.h
@@ -37,7 +37,7 @@ namespace Plugin {
         PackagerImplementation(const PackagerImplementation&) = delete;
         PackagerImplementation& operator=(const PackagerImplementation&) = delete;
 
-        class EXTERNAL Config : public Core::JSON::Container {
+        class Config : public Core::JSON::Container {
         public:
             Config()
                 : Core::JSON::Container()

--- a/PlayerInfo/Dolby.h
+++ b/PlayerInfo/Dolby.h
@@ -26,9 +26,9 @@
 extern "C" {
 #endif
 
-EXTERNAL void set_audio_output_type(enum WPEFramework::Exchange::Dolby::IOutput::Type type);
+void set_audio_output_type(enum WPEFramework::Exchange::Dolby::IOutput::Type type);
 
-EXTERNAL enum WPEFramework::Exchange::Dolby::IOutput::Type get_audio_output_type(void);
+enum WPEFramework::Exchange::Dolby::IOutput::Type get_audio_output_type(void);
 
 #ifdef __cplusplus
 }

--- a/PlayerInfo/Dolby/include/Dolby.h
+++ b/PlayerInfo/Dolby/include/Dolby.h
@@ -34,7 +34,7 @@ extern "C" {
  *  - ERROR_ILLEGAL_STATE - The audio device could not be initialized.
  *  - ERROR_GENERAL - Setting the parameter has failed.
  */
-EXTERNAL uint32_t 
+uint32_t 
 set_audio_output_type(const enum WPEFramework::Exchange::Dolby::IOutput::Type type);
 
 /**
@@ -48,7 +48,7 @@ set_audio_output_type(const enum WPEFramework::Exchange::Dolby::IOutput::Type ty
  * 
  * @return Type returned by the query.
  */
-EXTERNAL enum WPEFramework::Exchange::Dolby::IOutput::Type 
+enum WPEFramework::Exchange::Dolby::IOutput::Type 
 get_audio_output_type(uint32_t& error);
 
 #ifdef __cplusplus

--- a/Power/Implementation.h
+++ b/Power/Implementation.h
@@ -34,34 +34,34 @@ typedef void (*power_state_change)(void* userData, enum WPEFramework::Exchange::
 /**
  * Function to initialize and deinitialize the module
  */
-EXTERNAL void power_initialize(power_state_change callback, void* userData, const char* config,
+void power_initialize(power_state_change callback, void* userData, const char* config,
         const enum WPEFramework::Exchange::IPower::PCState persistedState);
-EXTERNAL void power_deinitialize();
+void power_deinitialize();
 
 /**
  * Function to request a power state change 
  */
-EXTERNAL uint32_t power_set_state(const enum WPEFramework::Exchange::IPower::PCState state, const uint32_t sleepTime);
+uint32_t power_set_state(const enum WPEFramework::Exchange::IPower::PCState state, const uint32_t sleepTime);
 
 /**
  * Function to request the current power state
  */
-EXTERNAL enum WPEFramework::Exchange::IPower::PCState power_get_state();
+enum WPEFramework::Exchange::IPower::PCState power_get_state();
 
 /**
  * Function to check power state is supported by platform
  */
-EXTERNAL bool is_power_state_supported(const enum WPEFramework::Exchange::IPower::PCState state);
+bool is_power_state_supported(const enum WPEFramework::Exchange::IPower::PCState state);
 
 /**
  * Function to request the persistent power state from platform.
  */
-EXTERNAL enum WPEFramework::Exchange::IPower::PCState power_get_persisted_state();
+enum WPEFramework::Exchange::IPower::PCState power_get_persisted_state();
 
 /**
  * Function to save current power state for persistent recovery in platform.
  */
-EXTERNAL void power_set_persisted_state(const enum WPEFramework::Exchange::IPower::PCState);
+void power_set_persisted_state(const enum WPEFramework::Exchange::IPower::PCState);
 
 #ifdef __cplusplus
 }

--- a/SecurityAgent/AccessControlList.h
+++ b/SecurityAgent/AccessControlList.h
@@ -82,14 +82,14 @@ namespace Plugin {
     //   }
     // },
 
-    class EXTERNAL AccessControlList {
+    class AccessControlList {
     public:
         enum mode {
             BLOCKED,
             ALLOWED
         };
     private:
-        class EXTERNAL JSONACL : public Core::JSON::Container {
+        class JSONACL : public Core::JSON::Container {
         public:
             class Plugins : public Core::JSON::Container {
             public:

--- a/TimeSync/NTPClient.h
+++ b/TimeSync/NTPClient.h
@@ -26,7 +26,7 @@
 namespace WPEFramework {
 namespace Plugin {
 
-    class EXTERNAL NTPClient : public Core::SocketDatagram, public Exchange::ITimeSync, public PluginHost::ISubSystem::ITime {
+    class NTPClient : public Core::SocketDatagram, public Exchange::ITimeSync, public PluginHost::ISubSystem::ITime {
     public:
         static constexpr uint32_t MilliSeconds = 1000;
         static constexpr uint32_t MicroSeconds = 1000 * MilliSeconds;

--- a/WifiControl/Controller.cpp
+++ b/WifiControl/Controller.cpp
@@ -41,7 +41,7 @@ namespace WPASupplicant {
 
     static const TCHAR hexArray[] = "0123456789abcdef";
 
-    class EXTERNAL Communication {
+    class Communication {
     private:
         Communication(const Communication& a_Copy) = delete;
         Communication& operator=(const Communication& a_RHS) = delete;

--- a/examples/FileTransferClient/FileTransferClient.cpp
+++ b/examples/FileTransferClient/FileTransferClient.cpp
@@ -25,8 +25,6 @@
 #include <iostream>
 #include <fstream>
 
-#undef EXTERNAL
-
 using namespace WPEFramework;
 
 namespace WPEFramework {

--- a/examples/JSONRPCPlugin/Data.h
+++ b/examples/JSONRPCPlugin/Data.h
@@ -30,7 +30,7 @@ namespace Data {
         uint32_t Height;
     };
 
-    class EXTERNAL Geometry : public Core::JSON::Container {
+    class Geometry : public Core::JSON::Container {
     public:
         Geometry()
             : Core::JSON::Container()
@@ -91,7 +91,7 @@ namespace Data {
         Core::JSON::DecUInt32 Width;
         Core::JSON::DecUInt32 Height;
     };
-    class EXTERNAL Time : public Core::JSON::Container {
+    class Time : public Core::JSON::Container {
     private:
         Time(const Time&) = delete;
         Time& operator=(const Time&) = delete;
@@ -129,7 +129,7 @@ namespace Data {
         Core::JSON::DecUInt8 Minutes;
         Core::JSON::DecUInt8 Seconds;
     };
-    class EXTERNAL Parameters : public Core::JSON::Container {
+    class Parameters : public Core::JSON::Container {
     private:
         Parameters(const Parameters&) = delete;
         Parameters& operator=(const Parameters&) = delete;
@@ -161,7 +161,7 @@ namespace Data {
         Core::JSON::String Location;
         Core::JSON::Boolean UTC;
     };
-    class EXTERNAL MessageParameters : public Core::JSON::Container {
+    class MessageParameters : public Core::JSON::Container {
     private:
         MessageParameters(const MessageParameters&) = delete;
         MessageParameters& operator=(const MessageParameters&) = delete;
@@ -193,7 +193,7 @@ namespace Data {
         Core::JSON::String Recipient;
         Core::JSON::String Message;
     };
-    class EXTERNAL Response : public Core::JSON::Container {
+    class Response : public Core::JSON::Container {
     private:
         Response(const Response&) = delete;
         Response& operator=(const Response&) = delete;

--- a/examples/OutOfProcessPlugin/OutOfProcessImplementation.cpp
+++ b/examples/OutOfProcessPlugin/OutOfProcessImplementation.cpp
@@ -461,7 +461,7 @@ namespace Plugin {
 
 namespace OutOfProcessPlugin {
 
-    class EXTERNAL MemoryObserverImpl : public Exchange::IMemory {
+    class MemoryObserverImpl : public Exchange::IMemory {
     private:
         MemoryObserverImpl();
         MemoryObserverImpl(const MemoryObserverImpl&);


### PR DESCRIPTION
As there is no need to use plugins as librraies by other plugins, there is no need
to define any class to be externally accessible. This commit cleans all EXTERNAL
keywords still available on classes. This should be a very low risk as all the
Module.h files would already undefine EXTERNAL and set it to an empty value :-)