### PR TITLE
[WINDOWS] The windows compiler does not allow dynamic storage on stack.

### DIFF
--- a/DIALServer/DIALServer.cpp
+++ b/DIALServer/DIALServer.cpp
@@ -396,7 +396,7 @@ namespace Plugin {
             response->Message = _T("Payload too long");
         } else {
             const string additionalDataUrl = (_T("http://localhost/") + app.Name() + _T("/") + _DefaultDataExtension);
-            TCHAR encodedDataUrl[additionalDataUrl.length() * 3 * sizeof(TCHAR)];
+            TCHAR* encodedDataUrl = reinterpret_cast<TCHAR*>(ALLOCA(additionalDataUrl.length() * 3 * sizeof(TCHAR)));
             Core::URL::Encode(additionalDataUrl.c_str(), static_cast<uint16_t>(additionalDataUrl.length()), encodedDataUrl, static_cast<uint16_t>(sizeof(encodedDataUrl)));
             string parameters = (app.AppURL() + (app.HasQueryParameter()? _T("&") : _T("?")) + _T("additionalDataUrl=") + encodedDataUrl);
 

--- a/DIALServer/Netflix.cpp
+++ b/DIALServer/Netflix.cpp
@@ -31,7 +31,9 @@ namespace DIALHandlers {
         Netflix(const Netflix&) = delete;
         Netflix& operator=(const Netflix&) = delete;
 
-    public:
+        #ifdef __WINDOWS__
+        #pragma warning(disable : 4355)
+        #endif
         Netflix(PluginHost::IShell* service, const Plugin::DIALServer::Config::App& config, Plugin::DIALServer *parent)
             : Default(service, config, parent)
             , _netflix(nullptr)
@@ -47,6 +49,10 @@ namespace DIALHandlers {
                 service->Register(&_notification);
             }
         }
+        #ifdef __WINDOWS__
+        #pragma warning(default : 4355)
+        #endif
+
         ~Netflix() override
         {
             Detach();
@@ -65,7 +71,7 @@ namespace DIALHandlers {
 
             if (payload.empty() == false) {
                 // Netflix expects the payload as urlencoded option "dial"
-                TCHAR encodedPayload[payload.length() * 3 * sizeof(TCHAR)];
+                TCHAR* encodedPayload = reinterpret_cast<TCHAR*>(ALLOCA(payload.length() * 3 * sizeof(TCHAR)));
                 Core::URL::Encode(payload.c_str(), static_cast<uint16_t>(payload.length()), encodedPayload, static_cast<uint16_t>(sizeof(encodedPayload)));
                 query = query + _T("&dial=") + encodedPayload;
             }


### PR DESCRIPTION
I thought windows (VS2019) is a pretty modern compiler but the dynamic allocation of arrays on a stack is not allowed. A I missing something. Used the old fashion ALLOCA() but please feedback if we could revert and have it compiling under windows as well..