### PR TITLE
WifiControl: update to avoid deadlock situation and doc/jponrpc interface updates

### DIFF
--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -1494,21 +1494,17 @@ namespace WPASupplicant {
         }
         inline uint32_t Connect(IConnectCallback* sink, const string& SSID, const uint64_t bssid)
         {
-            _adminLock.Lock();
 
             uint32_t result = _connectRequest.Invoke(sink, SSID, bssid);
 
-            _adminLock.Unlock();
 
             return (result);
         }
         inline uint32_t Revoke(IConnectCallback* sink)
         {
-            _adminLock.Lock();
 
             uint32_t result = _connectRequest.Revoke(sink);
 
-            _adminLock.Unlock();
 
             return (result);
         }
@@ -1551,7 +1547,6 @@ namespace WPASupplicant {
 
         inline void Notify(const events value)
         {
-            _adminLock.Lock();
 
             if (value == WPASupplicant::Controller::CTRL_EVENT_SSID_TEMP_DISABLED) {
                 _connectRequest.Completed(Core::ERROR_INVALID_SIGNATURE);
@@ -1560,6 +1555,7 @@ namespace WPASupplicant {
                 _connectRequest.Completed(Core::ERROR_NONE);
             }
 
+            _adminLock.Lock();
             if (_callback != nullptr) {
                 _callback->Dispatch(value);
             }

--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -1561,7 +1561,6 @@ namespace WPASupplicant {
 
         inline void Notify(const events value)
         {
-            _adminLock.Lock();
 
             if (value == WPASupplicant::Controller::CTRL_EVENT_SSID_TEMP_DISABLED) {
                 _connectRequest.Completed(Core::ERROR_INVALID_SIGNATURE);
@@ -1570,6 +1569,7 @@ namespace WPASupplicant {
                 _connectRequest.Completed(Core::ERROR_NONE);
             }
 
+            _adminLock.Lock();
             if (_callback != nullptr) {
                 _callback->Dispatch(value);
             }

--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -802,31 +802,43 @@ namespace WPASupplicant {
         public:
             uint32_t Invoke(IConnectCallback* callback, const string& ssid, const uint64_t& bssid) {
 
-                uint32_t result = (_callback != nullptr ? Core::ERROR_INPROGRESS        :
-                                  (bssid     == 0       ? Core::ERROR_INCOMPLETE_CONFIG :
-                                  (_parent.Current().empty() == false ? Core::ERROR_ALREADY_CONNECTED :
-                                                          Core::ERROR_UNKNOWN_KEY       )));
+                uint32_t result = ((bssid == 0) ? Core::ERROR_INCOMPLETE_CONFIG :
+                                  ((_parent.Current().empty() == false) ? Core::ERROR_ALREADY_CONNECTED :
+                                  Core::ERROR_UNKNOWN_KEY));
 
                 if (result == Core::ERROR_UNKNOWN_KEY) {
 
-                    EnabledContainer::iterator index(_parent._enabled.find(ssid));
+                    _adminLock.Lock();
+                    if (_callback == nullptr) {
 
-                    if (index != _parent._enabled.end()) {
+                        EnabledContainer::iterator index(_parent._enabled.find(ssid));
 
-                        result = Core::ERROR_ASYNC_FAILED;
+                        if (index != _parent._enabled.end()) {
 
-                        if (Request::Set (string(_TXT("SELECT_NETWORK ")) + Core::NumberType<uint32_t>(index->second.Id()).Text()) == true) {
+                            result = Core::ERROR_ASYNC_FAILED;
 
-                            _bssid = bssid;
-                            _ssid = ssid;
-                            _state = connection::SELECT;
-                            _callback = callback;
-                            result = Core::ERROR_NONE;
+                            if (Request::Set (string(_TXT("SELECT_NETWORK ")) + Core::NumberType<uint32_t>(index->second.Id()).Text()) == true) {
 
-                            _parent.Submit(this);
+                                _bssid = bssid;
+                                _ssid = ssid;
+                                _state = connection::SELECT;
+                                _callback = callback;
+                                _adminLock.Unlock();
 
-                            index->second.State(ConfigInfo::SELECTED);
+                                result = Core::ERROR_NONE;
+
+                                _parent.Submit(this);
+
+                                index->second.State(ConfigInfo::SELECTED);
+                            } else {
+                                _adminLock.Unlock();
+                            }
+                        } else {
+                            _adminLock.Unlock();
                         }
+                    } else {
+                       _adminLock.Unlock();
+                       result = Core::ERROR_INPROGRESS;
                     }
                 }
 
@@ -857,6 +869,7 @@ namespace WPASupplicant {
                 uint32_t result = Core::ERROR_REQUEST_SUBMITTED;
                 string newCommand;
 
+                _adminLock.Lock();
                 if (abort == true) {
                     result = Core::ERROR_ASYNC_ABORTED;
                 } 
@@ -883,13 +896,12 @@ namespace WPASupplicant {
                 } 
                 else if (_state != connection::WAITING) {
                 
-                    _adminLock.Lock();
 
                     if (_callback != nullptr) {
                         _callback->Completed(result);
                     }
-                    _adminLock.Unlock();
                 }
+                _adminLock.Unlock();
             }
             void Completed(const uint32_t result) {
 
@@ -900,13 +912,16 @@ namespace WPASupplicant {
                     _error = result;
                     _state = connection::ERROR;
 
+                    _adminLock.Unlock();
                     Request::Set(string(_TXT("DISCONNECT")));
                     _parent.Submit(this);
                 }
                 else if ((_callback != nullptr) && (_state == connection::WAITING)) {
                     _callback->Completed(result);
+                    _adminLock.Unlock();
+                } else {
+                    _adminLock.Unlock();
                 }
-                _adminLock.Unlock();
             }
 
         private:
@@ -1501,23 +1516,11 @@ namespace WPASupplicant {
         }
         inline uint32_t Connect(IConnectCallback* sink, const string& SSID, const uint64_t bssid)
         {
-            _adminLock.Lock();
-
-            uint32_t result = _connectRequest.Invoke(sink, SSID, bssid);
-
-            _adminLock.Unlock();
-
-            return (result);
+            return (_connectRequest.Invoke(sink, SSID, bssid));
         }
         inline uint32_t Revoke(IConnectCallback* sink)
         {
-            _adminLock.Lock();
-
-            uint32_t result = _connectRequest.Revoke(sink);
-
-            _adminLock.Unlock();
-
-            return (result);
+            return (_connectRequest.Revoke(sink));
         }
         inline uint32_t Disconnect(const string& SSID)
         {

--- a/WifiControl/WifiControlJsonRpc.cpp
+++ b/WifiControl/WifiControlJsonRpc.cpp
@@ -39,7 +39,7 @@
         uint32_t get_config(const string& index, JsonData::WifiControl::ConfigInfo& response) const;
         uint32_t set_config(const string& index, const JsonData::WifiControl::ConfigInfo& param);
         uint32_t set_debug(const Core::JSON::DecUInt32& param);
-        void event_scanresults(const Core::JSON::ArrayType<JsonData::WifiControl::NetworkInfo>& list)
+        void event_scanresults(const Core::JSON::ArrayType<JsonData::WifiControl::NetworkInfo>& list);
         void event_networkchange();
         void event_connectionchange(const string& ssid);
 */
@@ -128,8 +128,10 @@ namespace Plugin {
     // Return codes:
     //  - ERROR_NONE: Success
     //  - ERROR_UNKNOWN_KEY: Returned when the network with a the given SSID doesn't exists
-    //  - ERROR_ASYNC_ABORTED: Returned when connection attempt fails for other reasons
+    //  - ERROR_BAD_REQUEST: Returned when connection fails if there is no associated bssid to connect and not defined as AccessPoint. Rescan and try to connect"
+    //  - ERROR_INVALID_SIGNATURE: Returned when connection is attempted with wrong password
     //  - ERROR_ALREADY_CONNECTED: Returned when there is already a connection
+    //  - ERROR_ASYNC_ABORTED: Returned when connection attempt fails for other reasons
     uint32_t WifiControl::endpoint_connect(const DeleteParamsInfo& params)
     {
         const string& ssid = params.Ssid.Value();

--- a/WifiControl/WifiControlJsonRpc.cpp
+++ b/WifiControl/WifiControlJsonRpc.cpp
@@ -129,6 +129,7 @@ namespace Plugin {
     //  - ERROR_NONE: Success
     //  - ERROR_UNKNOWN_KEY: Returned when the network with a the given SSID doesn't exists
     //  - ERROR_ASYNC_ABORTED: Returned when connection attempt fails for other reasons
+    //  - ERROR_ALREADY_CONNECTED: Returned when there is already a connection
     uint32_t WifiControl::endpoint_connect(const DeleteParamsInfo& params)
     {
         const string& ssid = params.Ssid.Value();

--- a/WifiControl/doc/WifiControlPlugin.md
+++ b/WifiControl/doc/WifiControlPlugin.md
@@ -244,9 +244,9 @@ Also see: [connectionchange](#event.connectionchange)
 | :-------- | :-------- | :-------- |
 | 22 | ```ERROR_UNKNOWN_KEY``` | Returned when the network with a the given SSID doesn't exists |
 | 30 | ```ERROR_BAD_REQUEST``` | Returned when connection fails if there is no associated bssid to connect and not defined as AccessPoint. Rescan and try to connect |
-| 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
-| 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
+| 38 | ```ERROR_INVALID_SIGNATURE``` | Returned when connection is attempted with wrong password |
 | 9 | ```ERROR_ALREADY_CONNECTED``` | Returned when there is already a connection |
+| 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
 
 ### Example
 

--- a/WifiControl/doc/WifiControlPlugin.md
+++ b/WifiControl/doc/WifiControlPlugin.md
@@ -245,6 +245,8 @@ Also see: [connectionchange](#event.connectionchange)
 | 22 | ```ERROR_UNKNOWN_KEY``` | Returned when the network with a the given SSID doesn't exists |
 | 30 | ```ERROR_BAD_REQUEST``` | Returned when connection fails if there is no associated bssid to connect and not defined as AccessPoint. Rescan and try to connect |
 | 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
+| 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
+| 9 | ```ERROR_ALREADY_CONNECTED``` | Returned when there is already a connection |
 
 ### Example
 

--- a/WifiControl/doc/WifiControlPlugin.md
+++ b/WifiControl/doc/WifiControlPlugin.md
@@ -243,6 +243,7 @@ Also see: [connectionchange](#event.connectionchange)
 | Code | Message | Description |
 | :-------- | :-------- | :-------- |
 | 22 | ```ERROR_UNKNOWN_KEY``` | Returned when the network with a the given SSID doesn't exists |
+| 30 | ```ERROR_BAD_REQUEST``` | Returned when connection fails if there is no associated bssid to connect and not defined as AccessPoint. Rescan and try to connect |
 | 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
 
 ### Example
@@ -330,7 +331,7 @@ WifiControl interface properties:
 | [status](#property.status) <sup>RO</sup> | Network status |
 | [networks](#property.networks) <sup>RO</sup> | Available networks |
 | [configs](#property.configs) <sup>RO</sup> | All WiFi configurations |
-| [config](#property.config) | Single WiFi conifguration |
+| [config](#property.config) | Single WiFi configuration |
 | [debug](#property.debug) <sup>WO</sup> | Sets debug level |
 
 <a name="property.status"></a>
@@ -443,7 +444,7 @@ Provides access to the all WiFi configurations.
 | (property) | array | All WiFi configurations |
 | (property)[#] | object |  |
 | (property)[#].ssid | string | Identifier of a network |
-| (property)[#]?.type | string | <sup>*(optional)*</sup> Level of security (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *Enterprise*) |
+| (property)[#]?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means both WPA and WPA2 types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
 | (property)[#].hidden | boolean | Indicates whether a network is hidden |
 | (property)[#].accesspoint | boolean | Indicates if the network operates in AP mode |
 | (property)[#]?.psk | string | <sup>*(optional)*</sup> Network's PSK in plaintext (irrelevant if hash is provided) |
@@ -477,7 +478,7 @@ Provides access to the all WiFi configurations.
     "result": [
         {
             "ssid": "MyCorporateNetwork",
-            "type": "WPA",
+            "type": "WPA_WPA2",
             "hidden": false,
             "accesspoint": true,
             "psk": "secretpresharedkey",
@@ -491,15 +492,15 @@ Provides access to the all WiFi configurations.
 <a name="property.config"></a>
 ## *config <sup>property</sup>*
 
-Provides access to the single WiFi conifguration.
+Provides access to the single WiFi configuration.
 
 ### Value
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | object | Single WiFi conifguration |
+| (property) | object | Single WiFi configuration |
 | (property).ssid | string | Identifier of a network |
-| (property)?.type | string | <sup>*(optional)*</sup> Level of security (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *Enterprise*) |
+| (property)?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means both WPA and WPA2 types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
 | (property).hidden | boolean | Indicates whether a network is hidden |
 | (property).accesspoint | boolean | Indicates if the network operates in AP mode |
 | (property)?.psk | string | <sup>*(optional)*</sup> Network's PSK in plaintext (irrelevant if hash is provided) |
@@ -535,7 +536,7 @@ Provides access to the single WiFi conifguration.
     "id": 1234567890,
     "result": {
         "ssid": "MyCorporateNetwork",
-        "type": "WPA",
+        "type": "WPA_WPA2",
         "hidden": false,
         "accesspoint": true,
         "psk": "secretpresharedkey",
@@ -554,7 +555,7 @@ Provides access to the single WiFi conifguration.
     "method": "WifiControl.1.config@MyCorporateNetwork",
     "params": {
         "ssid": "MyCorporateNetwork",
-        "type": "WPA",
+        "type": "WPA_WPA2",
         "hidden": false,
         "accesspoint": true,
         "psk": "secretpresharedkey",
@@ -616,7 +617,7 @@ Provides access to the sets debug level.
 <a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the plugin, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers.Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the WifiControl plugin:
 
@@ -625,8 +626,8 @@ WifiControl interface events:
 | Event | Description |
 | :-------- | :-------- |
 | [scanresults](#event.scanresults) | Signals that the scan operation has finished |
-| [networkchange](#event.networkchange) | Signals that a network property has changed  |
-| [connectionchange](#event.connectionchange) | Notifies about connection state change  |
+| [networkchange](#event.networkchange) | Signals that a network property has changed |
+| [connectionchange](#event.connectionchange) | Notifies about connection state change |
 
 <a name="event.scanresults"></a>
 ## *scanresults <sup>event</sup>*
@@ -676,7 +677,7 @@ Signals that the scan operation has finished.
 <a name="event.networkchange"></a>
 ## *networkchange <sup>event</sup>*
 
-Signals that a network property has changed (e.g. frequency).
+Signals that a network property has changed. e.g. frequency.
 
 ### Parameters
 
@@ -693,7 +694,7 @@ This event carries no parameters.
 <a name="event.connectionchange"></a>
 ## *connectionchange <sup>event</sup>*
 
-Notifies about connection state change (i.e. connected/disconnected).
+Notifies about connection state change. i.e. connected/disconnected.
 
 ### Parameters
 


### PR DESCRIPTION
1. Currently same lock is used inside the Controller class for connect/disconnect/scan as well SendData/ReceiveData. This will sendup deadlock some times since the calls are happening in the two way direction. Hence removed the locks inside the connect/disconnect/scan of controller class. Also used lock from JsonRPC/ReST calls during the invoke of _controller->connect/disconnect/scan  to ensure there is no parallel calls and end up with some overwrite on the submitted requests.

2. Updated document and WifiControlJsonRPC comments to align with latest WifiControl.json