### PR TITLE
[IOConnector] Fix for Issue #161

### DIFF
--- a/IOConnector/IOConnector.config
+++ b/IOConnector/IOConnector.config
@@ -72,6 +72,6 @@ if(PLUGIN_IOCONNECTOR_PINS)
         end()
         ans(pin-${label})
 
-        map_append(${configuration} pins ${pin-${label}})
-endforeach()
+        map_append(${configuration} pins ___array___ ${pin-${label}})
+    endforeach()
 endif()


### PR DESCRIPTION
Root cause: `pins` configuration expected is an array but single GPIO configuration is not creating it as array hence parse fails.
Fix logic: Forcing all `pins` configurations to be added as array in generated json.

Signed-off-by: Arun Madhavan <Arun_Madhavan@comcast.com>