### PR TITLE
HP40A-217:Fix for Connect hang issue

### DIFF
--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -889,16 +889,13 @@ namespace WPASupplicant {
                 else {
                     _state = connection::WAITING;
                 }
-                _adminLock.Unlock();
 
                 if ((newCommand.empty() == false) && (Request::Set(newCommand) == true)) {
+                    _adminLock.Unlock();
                     _parent.Submit(this);
                 } 
-                else {
-                    _adminLock.Lock();
-                    if ((_state != connection::WAITING) && (_callback != nullptr)) {
-                        _callback->Completed(result);
-                    }
+                else if ((_state != connection::WAITING) && (_callback != nullptr)) {
+                    _callback->Completed(result);
                     _adminLock.Unlock();
                 }
             }

--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -802,31 +802,43 @@ namespace WPASupplicant {
         public:
             uint32_t Invoke(IConnectCallback* callback, const string& ssid, const uint64_t& bssid) {
 
-                uint32_t result = (_callback != nullptr ? Core::ERROR_INPROGRESS        : 
-                                  (bssid     == 0       ? Core::ERROR_INCOMPLETE_CONFIG : 
-                                  (_parent.Current().empty() == false ? Core::ERROR_ALREADY_CONNECTED :
-                                                          Core::ERROR_UNKNOWN_KEY       )));
+                uint32_t result = ((bssid == 0) ? Core::ERROR_INCOMPLETE_CONFIG :
+                                  ((_parent.Current().empty() == false) ? Core::ERROR_ALREADY_CONNECTED :
+                                  Core::ERROR_UNKNOWN_KEY));
 
                 if (result == Core::ERROR_UNKNOWN_KEY) {
 
-                    EnabledContainer::iterator index(_parent._enabled.find(ssid));
+                    _adminLock.Lock();
+                    if (_callback == nullptr) {
 
-                    if (index != _parent._enabled.end()) {
+                        EnabledContainer::iterator index(_parent._enabled.find(ssid));
 
-                        result = Core::ERROR_ASYNC_FAILED;
+                        if (index != _parent._enabled.end()) {
 
-                        if (Request::Set (string(_TXT("SELECT_NETWORK ")) + Core::NumberType<uint32_t>(index->second.Id()).Text()) == true) {
+                            result = Core::ERROR_ASYNC_FAILED;
 
-                            _bssid = bssid;
-                            _ssid = ssid;
-                            _state = connection::SELECT;
-                            _callback = callback;
-                            result = Core::ERROR_NONE;
+                            if (Request::Set (string(_TXT("SELECT_NETWORK ")) + Core::NumberType<uint32_t>(index->second.Id()).Text()) == true) {
 
-                            _parent.Submit(this);
+                                _bssid = bssid;
+                                _ssid = ssid;
+                                _state = connection::SELECT;
+                                _callback = callback;
+                                _adminLock.Unlock();
 
-                            index->second.State(ConfigInfo::SELECTED);
+                                result = Core::ERROR_NONE;
+
+                                _parent.Submit(this);
+
+                                index->second.State(ConfigInfo::SELECTED);
+                            } else {
+                                _adminLock.Unlock();
+                            }
+                        } else {
+                            _adminLock.Unlock();
                         }
+                    } else {
+                       _adminLock.Unlock();
+                       result = Core::ERROR_INPROGRESS;
                     }
                 }
 
@@ -857,6 +869,7 @@ namespace WPASupplicant {
                 uint32_t result = Core::ERROR_REQUEST_SUBMITTED;
                 string newCommand;
 
+                _adminLock.Lock();
                 if (abort == true) {
                     result = Core::ERROR_ASYNC_ABORTED;
                 } 
@@ -883,13 +896,12 @@ namespace WPASupplicant {
                 } 
                 else if (_state != connection::WAITING) {
                 
-                    _adminLock.Lock();
 
                     if (_callback != nullptr) {
                         _callback->Completed(result);
                     }
-                    _adminLock.Unlock();
                 }
+                _adminLock.Unlock();
             }
             void Completed(const uint32_t result) {
 
@@ -900,13 +912,16 @@ namespace WPASupplicant {
                     _error = result;
                     _state = connection::ERROR;
 
+                    _adminLock.Unlock();
                     Request::Set(string(_TXT("DISCONNECT")));
                     _parent.Submit(this);
                 }
                 else if ((_callback != nullptr) && (_state == connection::WAITING)) {
                     _callback->Completed(result);
+                    _adminLock.Unlock();
+                } else {
+                    _adminLock.Unlock();
                 }
-                _adminLock.Unlock();
             }
 
         private:
@@ -1494,23 +1509,11 @@ namespace WPASupplicant {
         }
         inline uint32_t Connect(IConnectCallback* sink, const string& SSID, const uint64_t bssid)
         {
-            _adminLock.Lock();
-
-            uint32_t result = _connectRequest.Invoke(sink, SSID, bssid);
-
-            _adminLock.Unlock();
-
-            return (result);
+            return (_connectRequest.Invoke(sink, SSID, bssid));
         }
         inline uint32_t Revoke(IConnectCallback* sink)
         {
-            _adminLock.Lock();
-
-            uint32_t result = _connectRequest.Revoke(sink);
-
-            _adminLock.Unlock();
-
-            return (result);
+            return (_connectRequest.Revoke(sink));
         }
         inline uint32_t Disconnect(const string& SSID)
         {
@@ -1551,7 +1554,6 @@ namespace WPASupplicant {
 
         inline void Notify(const events value)
         {
-            _adminLock.Lock();
 
             if (value == WPASupplicant::Controller::CTRL_EVENT_SSID_TEMP_DISABLED) {
                 _connectRequest.Completed(Core::ERROR_INVALID_SIGNATURE);
@@ -1559,6 +1561,8 @@ namespace WPASupplicant {
             else if (value == WPASupplicant::Controller::CTRL_EVENT_CONNECTED) {
                 _connectRequest.Completed(Core::ERROR_NONE);
             }
+
+            _adminLock.Lock();
 
             if (_callback != nullptr) {
                 _callback->Dispatch(value);

--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -898,6 +898,9 @@ namespace WPASupplicant {
                     _callback->Completed(result);
                     _adminLock.Unlock();
                 }
+                else {
+                    _adminLock.Unlock();
+                }
             }
             void Completed(const uint32_t result) {
 

--- a/WifiControl/WifiControlJsonRpc.cpp
+++ b/WifiControl/WifiControlJsonRpc.cpp
@@ -35,9 +35,9 @@
         uint32_t endpoint_disconnect(const JsonData::WifiControl::DeleteParamsInfo& params);
         uint32_t get_status(JsonData::WifiControl::StatusData& response) const;
         uint32_t get_networks(Core::JSON::ArrayType<JsonData::WifiControl::NetworkInfo>& response) const;
-        uint32_t get_config(const string& index, JsonData::WifiControl::ConfigData& response) const;
-        uint32_t set_config(const string& index, const JsonData::WifiControl::ConfigData& param);
-        uint32_t get_debug(Core::JSON::DecUInt32& response) const;
+        uint32_t get_configs(Core::JSON::ArrayType<JsonData::WifiControl::ConfigInfo>& response) const;
+        uint32_t get_config(const string& index, JsonData::WifiControl::ConfigInfo& response) const;
+        uint32_t set_config(const string& index, const JsonData::WifiControl::ConfigInfo& param);
         uint32_t set_debug(const Core::JSON::DecUInt32& param);
         void event_scanresults(const Core::JSON::ArrayType<JsonData::WifiControl::NetworkInfo>& list);
         void event_networkchange();
@@ -94,7 +94,7 @@ namespace Plugin {
         return Core::ERROR_NONE;
     }
 
-    // Method: store - Stores configurations in the permanent storage
+    // Method: store - Stores the configurations in persistent storage
     // Return codes:
     //  - ERROR_NONE: Success
     //  - ERROR_WRITE_ERROR: Returned when the operation failed
@@ -114,7 +114,7 @@ namespace Plugin {
         return result;
     }
 
-    // Method: scan - Searches for an available networks
+    // Method: scan - Searches for available networks
     // Return codes:
     //  - ERROR_NONE: Success
     //  - ERROR_INPROGRESS: Returned when scan is already in progress
@@ -124,10 +124,13 @@ namespace Plugin {
         return _controller->Scan();
     }
 
-    // Method: connect - Attempt connection to the specified network
+    // Method: connect - Attempts connection to a network
     // Return codes:
     //  - ERROR_NONE: Success
     //  - ERROR_UNKNOWN_KEY: Returned when the network with a the given SSID doesn't exists
+    //  - ERROR_BAD_REQUEST: Returned when connection fails if there is no associated bssid to connect and not defined as AccessPoint. Rescan and try to connect"
+    //  - ERROR_INVALID_SIGNATURE: Returned when connection is attempted with wrong password
+    //  - ERROR_ALREADY_CONNECTED: Returned when there is already a connection
     //  - ERROR_ASYNC_ABORTED: Returned when connection attempt fails for other reasons
     uint32_t WifiControl::endpoint_connect(const DeleteParamsInfo& params)
     {
@@ -138,7 +141,7 @@ namespace Plugin {
         return _controller->Connect(ssid);
     }
 
-    // Method: disconnect - Disconnects from the specified network
+    // Method: disconnect - Disconnects from a network
     // Return codes:
     //  - ERROR_NONE: Success
     //  - ERROR_UNKNOWN_KEY: Returned when the network with a the given SSID doesn't exists
@@ -150,7 +153,7 @@ namespace Plugin {
         return _controller->Disconnect(ssid);
     }
 
-    // Property: status - Returns the current status information
+    // Property: status - Network status
     // Return codes:
     //  - ERROR_NONE: Success
     uint32_t WifiControl::get_status(StatusData& response) const
@@ -161,7 +164,7 @@ namespace Plugin {
         return Core::ERROR_NONE;
     }
 
-    // Property: networks - Returns information about available networks
+    // Property: networks - Available networks
     // Return codes:
     //  - ERROR_NONE: Success
     uint32_t WifiControl::get_networks(Core::JSON::ArrayType<NetworkInfo>& response) const
@@ -176,11 +179,27 @@ namespace Plugin {
         return Core::ERROR_NONE;
     }
 
-    // Property: config - Returns information about configuration of the specified network(s) (FIXME!!!)
+    // Property: configs - All WiFi configurations
     // Return codes:
     //  - ERROR_NONE: Success
-    //  - ERROR_UNKNOWN_KEY: Config does not exist
-    //  - ERROR_INCOMPLETE_CONFIG: Passed in config is invalid
+    //  - ERROR_UNKNOWN_KEY: Configuration does not exist
+    uint32_t WifiControl::get_configs(Core::JSON::ArrayType<ConfigInfo>& response) const
+    {
+        WPASupplicant::Config::Iterator list(_controller->Configs());
+        while (list.Next() == true) {
+            ConfigInfo conf;
+            WifiControl::FillConfig(list.Current(), conf);
+            response.Add(conf);
+        }
+
+        return Core::ERROR_NONE;
+    }
+
+    // Property: config - Single WiFi configuration
+    // Return codes:
+    //  - ERROR_NONE: Success
+    //  - ERROR_UNKNOWN_KEY: Configuration does not exist
+    //  - ERROR_INCOMPLETE_CONFIG: Passed in configuration is invalid
     uint32_t WifiControl::get_config(const string& ssid, ConfigInfo& response) const
     {
         uint32_t result = Core::ERROR_UNKNOWN_KEY;
@@ -195,27 +214,13 @@ namespace Plugin {
         return result;
     }
 
-    // Property: configs - Network configuration (FIXME!!!)
+
+
+    // Property: config - Single WiFi configuration
     // Return codes:
     //  - ERROR_NONE: Success
-    //  - ERROR_UNKNOWN_KEY: Config does not exist
-    uint32_t WifiControl::get_configs(Core::JSON::ArrayType<ConfigInfo>& response) const
-    {
-        WPASupplicant::Config::Iterator list(_controller->Configs());
-        while (list.Next() == true) {
-            ConfigInfo conf;
-            WifiControl::FillConfig(list.Current(), conf);
-            response.Add(conf);
-        }
-
-        return Core::ERROR_NONE;
-    }
-
-    // Property: config - Returns information about configuration of the specified network(s) (FIXME!!!)
-    // Return codes:
-    //  - ERROR_NONE: Success
-    //  - ERROR_UNKNOWN_KEY: Config does not exist
-    //  - ERROR_INCOMPLETE_CONFIG: Passed in config is invalid
+    //  - ERROR_UNKNOWN_KEY: Configuration does not exist
+    //  - ERROR_INCOMPLETE_CONFIG: Passed in configuration is invalid
     uint32_t WifiControl::set_config(const string& ssid, const ConfigInfo& param)
     {
         uint32_t result = Core::ERROR_NONE;
@@ -229,7 +234,7 @@ namespace Plugin {
         return result;
     }
 
-    // Property: debug - Sets specified debug level
+    // Property: debug - Sets debug level
     // Return codes:
     //  - ERROR_NONE: Success
     //  - ERROR_UNAVAILABLE: Returned when the operation is unavailable
@@ -244,19 +249,19 @@ namespace Plugin {
         return result;
     }
 
-    // Event: scanresults - Signals that the scan operation has finished and carries results of it
+    // Event: scanresults - Signals that the scan operation has finished
     void WifiControl::event_scanresults(const Core::JSON::ArrayType<JsonData::WifiControl::NetworkInfo>& list)
     {
         Notify(_T("scanresults"), list);
     }
 
-    // Event: networkchange - Informs that something has changed with the network e
+    // Event: networkchange - Signals that a network property has changed
     void WifiControl::event_networkchange()
     {
         Notify(_T("networkchange"));
     }
 
-    // Event: connectionchange - Notifies about connection state change i
+    // Event: connectionchange - Notifies about connection state change
     void WifiControl::event_connectionchange(const string& ssid)
     {
         Core::JSON::String params;

--- a/WifiControl/doc/WifiControlPlugin.md
+++ b/WifiControl/doc/WifiControlPlugin.md
@@ -446,7 +446,7 @@ Provides access to the all WiFi configurations.
 | (property) | array | All WiFi configurations |
 | (property)[#] | object |  |
 | (property)[#].ssid | string | Identifier of a network |
-| (property)[#]?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means both WPA and WPA2 types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
+| (property)[#]?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means WPA, WPA2 and mixed types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
 | (property)[#].hidden | boolean | Indicates whether a network is hidden |
 | (property)[#].accesspoint | boolean | Indicates if the network operates in AP mode |
 | (property)[#]?.psk | string | <sup>*(optional)*</sup> Network's PSK in plaintext (irrelevant if hash is provided) |
@@ -502,7 +502,7 @@ Provides access to the single WiFi configuration.
 | :-------- | :-------- | :-------- |
 | (property) | object | Single WiFi configuration |
 | (property).ssid | string | Identifier of a network |
-| (property)?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means both WPA and WPA2 types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
+| (property)?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means WPA, WPA2 and mixed types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
 | (property).hidden | boolean | Indicates whether a network is hidden |
 | (property).accesspoint | boolean | Indicates if the network operates in AP mode |
 | (property)?.psk | string | <sup>*(optional)*</sup> Network's PSK in plaintext (irrelevant if hash is provided) |

--- a/WifiControl/doc/WifiControlPlugin.md
+++ b/WifiControl/doc/WifiControlPlugin.md
@@ -243,6 +243,9 @@ Also see: [connectionchange](#event.connectionchange)
 | Code | Message | Description |
 | :-------- | :-------- | :-------- |
 | 22 | ```ERROR_UNKNOWN_KEY``` | Returned when the network with a the given SSID doesn't exists |
+| 30 | ```ERROR_BAD_REQUEST``` | Returned when connection fails if there is no associated bssid to connect and not defined as AccessPoint. Rescan and try to connect |
+| 38 | ```ERROR_INVALID_SIGNATURE``` | Returned when connection is attempted with wrong password |
+| 9 | ```ERROR_ALREADY_CONNECTED``` | Returned when there is already a connection |
 | 4 | ```ERROR_ASYNC_ABORTED``` | Returned when connection attempt fails for other reasons |
 
 ### Example
@@ -330,7 +333,7 @@ WifiControl interface properties:
 | [status](#property.status) <sup>RO</sup> | Network status |
 | [networks](#property.networks) <sup>RO</sup> | Available networks |
 | [configs](#property.configs) <sup>RO</sup> | All WiFi configurations |
-| [config](#property.config) | Single WiFi conifguration |
+| [config](#property.config) | Single WiFi configuration |
 | [debug](#property.debug) <sup>WO</sup> | Sets debug level |
 
 <a name="property.status"></a>
@@ -443,7 +446,7 @@ Provides access to the all WiFi configurations.
 | (property) | array | All WiFi configurations |
 | (property)[#] | object |  |
 | (property)[#].ssid | string | Identifier of a network |
-| (property)[#]?.type | string | <sup>*(optional)*</sup> Level of security (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *Enterprise*) |
+| (property)[#]?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means both WPA and WPA2 types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
 | (property)[#].hidden | boolean | Indicates whether a network is hidden |
 | (property)[#].accesspoint | boolean | Indicates if the network operates in AP mode |
 | (property)[#]?.psk | string | <sup>*(optional)*</sup> Network's PSK in plaintext (irrelevant if hash is provided) |
@@ -477,7 +480,7 @@ Provides access to the all WiFi configurations.
     "result": [
         {
             "ssid": "MyCorporateNetwork",
-            "type": "WPA",
+            "type": "WPA_WPA2",
             "hidden": false,
             "accesspoint": true,
             "psk": "secretpresharedkey",
@@ -491,15 +494,15 @@ Provides access to the all WiFi configurations.
 <a name="property.config"></a>
 ## *config <sup>property</sup>*
 
-Provides access to the single WiFi conifguration.
+Provides access to the single WiFi configuration.
 
 ### Value
 
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
-| (property) | object | Single WiFi conifguration |
+| (property) | object | Single WiFi configuration |
 | (property).ssid | string | Identifier of a network |
-| (property)?.type | string | <sup>*(optional)*</sup> Level of security (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *Enterprise*) |
+| (property)?.type | string | <sup>*(optional)*</sup> Type of protection. WPA_WPA2 means both WPA and WPA2 types are allowed (must be one of the following: *Unknown*, *Unsecure*, *WPA*, *WPA2*, *WPA_WPA2*, *Enterprise*) |
 | (property).hidden | boolean | Indicates whether a network is hidden |
 | (property).accesspoint | boolean | Indicates if the network operates in AP mode |
 | (property)?.psk | string | <sup>*(optional)*</sup> Network's PSK in plaintext (irrelevant if hash is provided) |
@@ -535,7 +538,7 @@ Provides access to the single WiFi conifguration.
     "id": 1234567890,
     "result": {
         "ssid": "MyCorporateNetwork",
-        "type": "WPA",
+        "type": "WPA_WPA2",
         "hidden": false,
         "accesspoint": true,
         "psk": "secretpresharedkey",
@@ -554,7 +557,7 @@ Provides access to the single WiFi conifguration.
     "method": "WifiControl.1.config@MyCorporateNetwork",
     "params": {
         "ssid": "MyCorporateNetwork",
-        "type": "WPA",
+        "type": "WPA_WPA2",
         "hidden": false,
         "accesspoint": true,
         "psk": "secretpresharedkey",
@@ -616,7 +619,7 @@ Provides access to the sets debug level.
 <a name="head.Notifications"></a>
 # Notifications
 
-Notifications are autonomous events, triggered by the internals of the plugin, and broadcasted via JSON-RPC to all registered observers. Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
+Notifications are autonomous events, triggered by the internals of the implementation, and broadcasted via JSON-RPC to all registered observers.Refer to [[Thunder](#ref.Thunder)] for information on how to register for a notification.
 
 The following events are provided by the WifiControl plugin:
 
@@ -625,8 +628,8 @@ WifiControl interface events:
 | Event | Description |
 | :-------- | :-------- |
 | [scanresults](#event.scanresults) | Signals that the scan operation has finished |
-| [networkchange](#event.networkchange) | Signals that a network property has changed  |
-| [connectionchange](#event.connectionchange) | Notifies about connection state change  |
+| [networkchange](#event.networkchange) | Signals that a network property has changed |
+| [connectionchange](#event.connectionchange) | Notifies about connection state change |
 
 <a name="event.scanresults"></a>
 ## *scanresults <sup>event</sup>*
@@ -676,7 +679,7 @@ Signals that the scan operation has finished.
 <a name="event.networkchange"></a>
 ## *networkchange <sup>event</sup>*
 
-Signals that a network property has changed (e.g. frequency).
+Signals that a network property has changed. e.g. frequency.
 
 ### Parameters
 
@@ -693,7 +696,7 @@ This event carries no parameters.
 <a name="event.connectionchange"></a>
 ## *connectionchange <sup>event</sup>*
 
-Notifies about connection state change (i.e. connected/disconnected).
+Notifies about connection state change. i.e. connected/disconnected.
 
 ### Parameters
 


### PR DESCRIPTION
1. Avoid Lock over ConnectRequest calls to avoid lock over Trigger() which end up with deadlock
2. Documentation in both WifiControlJsonRPC API description and WifiControl.md files are updated