### PR TITLE
[json rpc example] Fix and add functionality

### DIFF
--- a/examples/JSONRPCClient/JSONRPCClient.cpp
+++ b/examples/JSONRPCClient/JSONRPCClient.cpp
@@ -125,11 +125,13 @@ void ShowMenu()
            "\tE : Invoke and exchange an opaque variant JSON parameter\n"
            "\tC : Callback, using a static method, wait for a response from the otherside a-synchronously\n"
            "\tG : Callback, using a class method, wait for a response from the otherside a-synchronously\n"
+           "\tK : Test server side Validation\n" 
            "\tD : Demonstrating the possibilities with JsonObject\n\n"
            "\tX : Measure COM Performance\n"
            "\tY : Measure JSONRPC performance\n"
            "\tZ : Measure MessagePack performance\n"
            "\tL : Legacy invoke on version 1 clueless...\n"
+           "\tN : Invoke on version 2 clueless...\n"
            "\t+ : Register for a-synchronous events on Version 1 interface\n"
            "\t- : Unregister for a-synchronous events on Version 1 interface\n"
            "\tA : Get a JSONWebToken for the set URL\n"
@@ -180,7 +182,7 @@ class MessageHandler {
 public:
     explicit MessageHandler(const string& recipient)
         : _recipient(recipient)
-        , _remoteObject(_T("JSONRPCPlugin.1"), (recipient + _T(".client.events")).c_str()) {
+        , _remoteObject(_T("JSONRPCPlugin.2"), (recipient + _T(".client.events")).c_str()) {
     }
 
     void message_received(const Core::JSON::String& message) {
@@ -780,6 +782,13 @@ int main(int argc, char** argv)
                  }
                  break;
             }
+            case 'K': {
+                // the following call is supposed to fail as it will not pass server side validation
+                Core::JSON::String result;
+                uint32_t errorcode = remoteObject.Invoke<void, Core::JSON::String>(1000, _T("checkvalidation"), result);
+                printf("Check server side validation: [%s], code = %s\n", result.Value().c_str(), Core::ErrorToString(errorcode));
+                break;
+            }
             case 'L':
             {
                 // !!!!!!!!! calling the clueless method on INTERFACE VERSION 1 !!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -792,7 +801,13 @@ int main(int argc, char** argv)
                 Core::JSON::String result;
                 result = _T("This should be an eche server on interface 1");
                 legacyObject.Invoke<Core::JSON::String, Core::JSON::String>(1000, _T("clueless"), result, result);
-                printf("received time: %s\n", result.Value().c_str());
+                printf("received message: %s\n", result.Value().c_str());
+                break;
+            }
+            case 'N':
+            {
+                // calling the clueless method on INTERFACE VERSION 2
+                remoteObject.Invoke<void, void>(1000, _T("clueless"));
                 break;
             }
             case '+':

--- a/examples/JSONRPCPlugin/JSONRPCPlugin.cpp
+++ b/examples/JSONRPCPlugin/JSONRPCPlugin.cpp
@@ -33,7 +33,7 @@ ENUM_CONVERSION_END(Data::Response::state)
 namespace Plugin
 {
     bool JSONRPCPlugin::Validation(const string& token, const string& method, const string& parameters) {
-        return (parameters.empty());
+        return (method != _T("checkvalidation"));
     }
 
     SERVICE_REGISTRATION(JSONRPCPlugin, 1, 0);
@@ -82,11 +82,14 @@ namespace Plugin
         Property<Core::JSON::DecUInt32>(_T("lookup"), &JSONRPCPlugin::get_array_value, nullptr, this);
         Property<Core::JSON::DecUInt32>(_T("store"), nullptr, &JSONRPCPlugin::set_array_value, this);
 
+        // PluginHost::JSONRPC method to register a JSONRPC method invocation that will not be alowed to execute as it  will not pass validation.
+        Register<void, Core::JSON::String>(_T("checkvalidation"), &JSONRPCPlugin::checkvalidation, this);
+
         // Methods for a "legaccy" version of the interfaces, the last parameter makes sure that all handlers are copied from the 
         // base interface to this "legacy" one...
         Core::JSONRPC::Handler& legacyVersion = JSONRPC::CreateHandler({ 1 }, *this); 
 
-        // The only method that is really differnt in version "1" needs to be registered. That is done by the next line.
+        // The only method that is really differnt in version "1" needs to be registered and replace the vother version one. That is done by the next line.
         legacyVersion.Register<Core::JSON::String, Core::JSON::String>(_T("clueless"), &JSONRPCPlugin::clueless2, this);
     }
     #ifdef __WINDOWS__

--- a/examples/JSONRPCPlugin/JSONRPCPlugin.h
+++ b/examples/JSONRPCPlugin/JSONRPCPlugin.h
@@ -31,6 +31,8 @@
 // within the plugin to make it available. 
 #include <interfaces/IMath.h>
 
+// note JMath tests disabled until this interface is generated from the IMath.h interface
+#if 0
 // From the source, included above (IMath.h) a precompiler will create a method that 
 // can connect a JSONRPC class to the interface implementation. This is typically done 
 // in the constructor of the plugin!
@@ -39,6 +41,7 @@
 // <interface name>::Register(PluginHost::JSONRPC& handler, <interface name>* implementation);
 // <interface name>::Unregister(PluginHost::JSONRPC& handler);
 #include <interfaces/JMath.h>
+#endif
 
 namespace WPEFramework {
 
@@ -575,6 +578,12 @@ namespace Plugin {
         {
             Core::ProxyType<Core::IDispatch> job(Core::ProxyType<Callback>::Create(this, connection));
             Core::IWorkerPool::Instance().Schedule(Core::Time::Now().Add(seconds * 1000), job);
+        }
+        uint32_t checkvalidation(Core::JSON::String& response)
+        {
+            response.SetQuoted(true);
+            response = "Passed Validation";
+            return (Core::ERROR_NONE);
         }
 
         // Methods for performance measurements


### PR DESCRIPTION
- Corrected JSOPN RPC Server side Validation example to not make most of the other examples fail because of this ;) Added a special Validation test to the server and client 
- added specific call to better test Versioned calls
- repaired message send test