### PR TITLE
Cobalt: Add Internet also in the precondition list to avoid loading hangs

### DIFF
--- a/Cobalt/Cobalt.config
+++ b/Cobalt/Cobalt.config
@@ -1,5 +1,5 @@
 set (autostart ${PLUGIN_COBALT_AUTOSTART})
-set (preconditions Platform Graphics)
+set (preconditions Platform Graphics Internet)
 
 map()
     kv(outofprocess ${PLUGIN_COBALT_OUTOFPROCESS})


### PR DESCRIPTION
Observed that some time Cobalt resume is either not loading the UI or just showing the loading screen.
This is happening if the Cobalt get activated before the Internet gets up. so adding this also into the dependency chain of Cobalt 