### PR TITLE
DIALServer: Added logic to retry for the configured interface ready

### DIFF
--- a/DIALServer/DIALServer.h
+++ b/DIALServer/DIALServer.h
@@ -1069,6 +1069,7 @@ namespace Plugin {
         void Deactivated(Exchange::IWebServer* webserver);
         void Activated(Exchange::ISwitchBoard* switchBoard);
         void Deactivated(Exchange::ISwitchBoard* switchBoard);
+        void Setup(PluginHost::IShell* service, Core::NodeId& selectedNode);
         void StartApplication(const Web::Request& request, Core::ProxyType<Web::Response>& response, AppInformation& app);
         void StopApplication(const Web::Request& request, Core::ProxyType<Web::Response>& response, AppInformation& app);
 


### PR DESCRIPTION
In the case of both eth0 and wlan0 are connected to device and wlan0 as the configure DIAL interface, DIAL is not activating during the WPEFramework boot up. 

During the analysis found that Wlan0 is getting activated only after some times the eth0 ready and In case of DIAL, it should try to activate once it get a Network event ready (event can be form any interface, but here it is always form eth0). So in such case DIAL will not get configured interface and the initialisation will be failed. So added some retry mechanism at the boot up to handle this situation.