### PR TITLE
WebKitBrowser: move JSONRPC unregister calls from the destructor to deinitialize sequence

### DIFF
--- a/WebKitBrowser/WebKitBrowser.cpp
+++ b/WebKitBrowser/WebKitBrowser.cpp
@@ -97,6 +97,7 @@ namespace Plugin {
         _service->Unregister(&_notification);
         _browser->Unregister(&_notification);
         _memory->Release();
+        UnregisterAll();
 
         PluginHost::IStateControl* stateControl(_browser->QueryInterface<PluginHost::IStateControl>());
 

--- a/WebKitBrowser/WebKitBrowser.h
+++ b/WebKitBrowser/WebKitBrowser.h
@@ -154,7 +154,6 @@ namespace Plugin {
 
         virtual ~WebKitBrowser()
         {
-            UnregisterAll();
             TRACE_L1("Destructor WebKitBrowser.%d", __LINE__);
         }
 


### PR DESCRIPTION
If we try to do the WebkitPlugin deactivation while the plugin is blocked state due to precondition not meet or similar reason, this endup with a crash of the WPEFramework. Currently we are doing the JSONRPC register only if the plugin instantiation is success. But the unregister is still handling from the WebKitBrowser destructor. So there is a chance to call UnregisterAll() with out doing the register and this is leading to the ASSERTION and  crashing the WPEFramework.

So better to make the Register and UnRegister sequences in. aligned way, hence the UnregisterAll() is moved to Deinitialization sequence.