### PR TITLE
By default do not start the resource monitor.

### DIFF
--- a/ResourceMonitor/ResourceMonitor.config
+++ b/ResourceMonitor/ResourceMonitor.config
@@ -1,4 +1,4 @@
-set (autostart true)
+set (autostart false)
 set (resumed true)
 
 map()


### PR DESCRIPTION
 QA can turn it on throught the ThunderUI