### PR TITLE
[WEBSERVER] Report an error scenario if it occures.

### DIFF
--- a/WebServer/WebServer.cpp
+++ b/WebServer/WebServer.cpp
@@ -63,27 +63,35 @@ namespace Plugin {
                 _server = nullptr;
 
             } else {
-                stateControl->Configure(_service);
+                uint32_t result = stateControl->Configure(_service);
                 stateControl->Release();
 
-                RPC::IRemoteConnection* connection = _service->RemoteConnection(_connectionId);
-
-                if(connection != nullptr) {
-                    _memory = WPEFramework::WebServer::MemoryObserver(connection);
-                    connection->Release();
-
-                    ASSERT(_memory != nullptr);
+                if (result != Core::ERROR_NONE) {
+                    message = _T("WebServer could not be configured.");
+                    _server->Release();
+                    _server = nullptr;
                 }
+                else {
+                    RPC::IRemoteConnection* connection = _service->RemoteConnection(_connectionId);
 
-                PluginHost::ISubSystem* subSystem = service->SubSystems();
+                    if (connection != nullptr) {
+                        _memory = WPEFramework::WebServer::MemoryObserver(connection);
+                        connection->Release();
 
-                if (subSystem != nullptr) {
-                    if (subSystem->IsActive(PluginHost::ISubSystem::WEBSOURCE) == true) {
-                        SYSLOG(Logging::Startup, (_T("WebSource is not defined as External !!")));
-                    } else {
-                        subSystem->Set(PluginHost::ISubSystem::WEBSOURCE, nullptr);
+                        ASSERT(_memory != nullptr);
                     }
-                    subSystem->Release();
+
+                    PluginHost::ISubSystem* subSystem = service->SubSystems();
+
+                    if (subSystem != nullptr) {
+                        if (subSystem->IsActive(PluginHost::ISubSystem::WEBSOURCE) == true) {
+                            SYSLOG(Logging::Startup, (_T("WebSource is not defined as External !!")));
+                        }
+                        else {
+                            subSystem->Set(PluginHost::ISubSystem::WEBSOURCE, nullptr);
+                        }
+                        subSystem->Release();
+                    }
                 }
             }
         }


### PR DESCRIPTION
If the port of the Webserver can not be opened because it is already in use, report an error and do not silently continue.