### PR TITLE
WifiControl: remove incomplete config during update

### DIFF
--- a/WifiControl/WifiControl.cpp
+++ b/WifiControl/WifiControl.cpp
@@ -320,6 +320,7 @@ namespace Plugin
                            result->ErrorCode = Web::STATUS_OK;
                            result->Message = _T("Config set.");
                         } else {
+                           _controller->Destroy(SSIDDecode(config->Ssid.Value()));
                            result->ErrorCode = Web::STATUS_BAD_REQUEST;
                            result->Message = _T("Incomplete Config.");
                         }
@@ -383,6 +384,7 @@ namespace Plugin
                         result->ErrorCode = Web::STATUS_OK;
                         result->Message = _T("Config set.");
                     } else {
+                        _controller->Destroy(SSIDDecode(config->Ssid.Value()));
                         result->ErrorCode = Web::STATUS_BAD_REQUEST;
                         result->Message = _T("Incomplete Config.");
                     }

--- a/WifiControl/WifiControlJsonRpc.cpp
+++ b/WifiControl/WifiControlJsonRpc.cpp
@@ -218,6 +218,7 @@ namespace Plugin {
             WPASupplicant::Config profile(_controller->Create(ssid));
             if (UpdateConfig(profile, param) != true) {
                 result = Core::ERROR_INCOMPLETE_CONFIG;
+                _controller->Destroy(ssid);
             }
         }
         return result;


### PR DESCRIPTION
Currently we are saving the incomplete config during the error, so better to clear that entry