### PR TITLE
IOConnector: Implement the Resource() interface method

### DIFF
--- a/IOConnector/IOConnector.cpp
+++ b/IOConnector/IOConnector.cpp
@@ -245,6 +245,20 @@ namespace Plugin
 
     }
 
+    /* virtual */ Exchange::IExternal* IOConnector::Resource(const uint32_t id)
+    {
+        Exchange::IExternal* result = nullptr;
+
+        Pins::iterator index = _pins.find(id);
+
+        if (index != _pins.end()) {
+            result = index->second.Pin();
+            result->AddRef();
+        }
+
+        return (result);
+    }
+
     /* virtual */ void IOConnector::Deinitialize(PluginHost::IShell * service)
     {
         ASSERT(_service == service);

--- a/IOConnector/IOConnector.h
+++ b/IOConnector/IOConnector.h
@@ -296,6 +296,7 @@ namespace Plugin {
         // -------------------------------------------------------------------------------------------------------
         void Register(ICatalog::INotification* sink) override;
         void Unregister(ICatalog::INotification* sink) override;
+        Exchange::IExternal* Resource(const uint32_t id) override;
 
         //  IWeb methods
         // -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The missing ICatalog::Resource() interface method is required for
directly getting the IExternal pointer to a give Pin ID, without having
to listen to ICatalog notifications.