### PR TITLE
[DisplayInfo] fix config generation

### DIFF
--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -18,7 +18,7 @@
 set(PLUGIN_NAME DisplayInfo)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
-set(PLUGIN_DISPLAYINFO_OUTOFPROCESS false CACHE BOOL "Enable monitor for the OutOfProcess plugin [true, false].")
+set(PLUGIN_DISPLAYINFO_OUTOFPROCESS false CACHE BOOL "Controls if the plugin should run in its own process [true, false].")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(${NAMESPACE}Definitions REQUIRED)

--- a/DisplayInfo/CMakeLists.txt
+++ b/DisplayInfo/CMakeLists.txt
@@ -18,6 +18,8 @@
 set(PLUGIN_NAME DisplayInfo)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_DISPLAYINFO_OUTOFPROCESS false CACHE BOOL "Enable monitor for the OutOfProcess plugin [true, false].")
+
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(${NAMESPACE}Definitions REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)

--- a/DisplayInfo/DisplayInfo.config
+++ b/DisplayInfo/DisplayInfo.config
@@ -33,11 +33,10 @@ end()
 
 ans(configuration)
 
-if(PLUGIN_DISPLAYINFO_INPROCESS)
-  map()
-    kv(outofprocess false)
-  end()
-  ans(runmode)
-  map_append(${configuration} root ${runmode})
-endif()
+map()
+  kv(outofprocess ${PLUGIN_DISPLAYINFO_OUTOFPROCESS})
+end()
+ans(runmode)
+map_append(${configuration} root ${runmode})
+
 


### PR DESCRIPTION
This fixes the parse error the DisplayInfo config would generate on Thunder startup (because an empty config section was generated), brings the in or out of process selection for the configuration in sync with how we do that for other plugins and makes the default selection now in process (previously it was not set in the config at all meaning it would be according the Thunder default  which is out of process.

(I must admit I would have had no clue how to fix it keeping it like it was and just not generating a config section at all when no setting inside it would have been selected :) )

