### PR TITLE
[DIALServer] Dynamic location IP for UPNP replies

### DIFF
--- a/DIALServer/DIALServer.cpp
+++ b/DIALServer/DIALServer.cpp
@@ -110,17 +110,21 @@ namespace Plugin {
 
     /* virtual */ uint32_t DIALServer::Default::AdditionalDataURL(string& url) const
     {
-        const uint16_t port = _parent->WebServerPort();
-        url = (_T("http://localhost") + ((port == 80)? _T("") : _T(":") + Core::NumberType<uint16_t>(port).Text()) + _T("/Service/DIALServer/Apps/") + _callsign + _T("/") + _DefaultDataExtension);
+        Core::URL baseUrl(_parent->BaseURL());
+        baseUrl.Host(string(_T("localhost"))); // replace the host with "localhost"
+        baseUrl.Path(baseUrl.Path().Value() + _T("/") + _callsign + _T("/") + _DefaultDataExtension);
+        url = baseUrl.Text();
         return (Core::ERROR_NONE);
     }
 
-    DIALServer::DIALServerImpl::DIALServerImpl(const string& MACAddress, const string& baseURL, const string& appPath)
+    DIALServer::DIALServerImpl::DIALServerImpl(const string& MACAddress, const Core::URL& locator, const string& appPath, const bool dynamicInterface)
         : BaseClass(5, false, Core::NodeId(DialServerInterface.AnyInterface(), DialServerInterface.PortNumber()), DialServerInterface.AnyInterface(), 1024, 1024)
         , _response(Core::ProxyType<Web::Response>::Create())
         , _destinations()
-        , _baseURL(baseURL)
+        , _locator(locator)
+        , _baseURL()
         , _appPath(appPath)
+        , _dynamicInterface(dynamicInterface)
     {
         _response->ErrorCode = Web::STATUS_OK;
         _response->Message = _T("OK");
@@ -134,6 +138,8 @@ namespace Plugin {
         // where currently Device identifier is passed in MACAddress.
         // _response->WakeUp = _T("MAC=") + MACAddress + _T(";Timeout=10");
         _response->Mode(Web::MARSHAL_UPPERCASE);
+
+        UpdateURL();
 
         if (Link().Open(1000) != Core::ERROR_NONE) {
             ASSERT(false && "Seems we can not open the DIAL discovery port");
@@ -153,6 +159,7 @@ namespace Plugin {
     {
         // upnp requests are empty so no body needed...
     }
+
     // Notification of a Partial Request received, time to attach a body..
     // upnp requests are empty so no body needed...
     /* virtual */ void DIALServer::DIALServerImpl::Received(Core::ProxyType<Web::Request>& request)
@@ -164,7 +171,13 @@ namespace Plugin {
             if (request->ST.Value() == _SearchTarget) {
 
                 TRACE(Protocol, (&(*request)));
+
+                _lock.Lock();
+
+                Host(Link().ReceivedInterface());
+
                 _destinations.push_back(sourceNode);
+
                 // remember the NodeId where this comes from.
                 if (_destinations.size() == 1) {
 
@@ -174,6 +187,8 @@ namespace Plugin {
 
                     Submit(_response);
                 }
+
+                _lock.Unlock();
             }
         }
     }
@@ -185,10 +200,13 @@ namespace Plugin {
 
         TRACE(Protocol, (&(*response)));
 
+        _lock.Lock();
+
         // Drop the current destination.
         _destinations.pop_front();
 
         if (_destinations.size() > 0) {
+
             _response->Location = URL() + '/' + _DefaultAppInfoDevice;
 
             // Move on to notifying the next one.
@@ -196,6 +214,8 @@ namespace Plugin {
 
             Submit(response);
         }
+
+        _lock.Unlock();
     }
 
     // Notification of a channel state change..
@@ -298,12 +318,13 @@ namespace Plugin {
             _service = service;
             _dialURL = Core::URL(service->Accessor());
             _dialURL.Host(selectedNode.HostAddress());
-            _dialPath = '/' + _dialURL.Path().Value();
-            _webServerPort = _dialURL.Port().IsSet() ? _dialURL.Port().Value() : 80;
+            if (_dialURL.Port().IsSet() == false) {
+                _dialURL.Port(80);
+            }
 
             // TODO: THis used to be the MAC, but I think  it is just a unique number, otherwise, we need the MAC
             //       that goes with the selectedNode !!!!
-            _dialServiceImpl = new DIALServerImpl(deviceId, _dialURL.Text(), _DefaultAppInfoPath);
+            _dialServiceImpl = new DIALServerImpl(deviceId, _dialURL, _DefaultAppInfoPath, selectedNode.IsAnyInterface());
 
             ASSERT(_dialServiceImpl != nullptr);
 
@@ -512,11 +533,9 @@ namespace Plugin {
                     result->Body(_deviceInfo);
                     result->ContentType = Web::MIME_TEXT_XML;
 
-                    Core::URL newURL;
-                    _dialServiceImpl->URL(newURL);
-
-                    result->ApplicationURL = newURL;
-                    TRACE(Protocol, (static_cast<const string&>(*_deviceInfo), &newURL));
+                    const string url = _dialServiceImpl->URL();
+                    result->ApplicationURL = Core::URL(url);
+                    TRACE(Protocol, (static_cast<const string&>(*_deviceInfo), url));
                 }
             } else {
                 auto selectedApp(_appInfo.find(keyword));
@@ -637,6 +656,7 @@ namespace Plugin {
         }
 
         TRACE(Protocol, (&(*result)));
+
         return (result);
     }
 
@@ -658,18 +678,15 @@ namespace Plugin {
 
     void DIALServer::Activated(Exchange::IWebServer* pluginInterface)
     {
-        string remote(_dialURL.Host().Value() + ':' + (_dialURL.Port().IsSet() ? Core::NumberType<uint16_t>(_dialURL.Port().Value()).Text() : _T("80")));
-
         _adminLock.Lock();
 
         // Let's set the URL of the WebServer, as it is active :-)
-        _dialServiceImpl->Locator(pluginInterface->Accessor() + _dialPath);
-
-        Core::URL url = Core::URL(pluginInterface->Accessor());
-        _webServerPort = url.Port().IsSet() ? url.Port().Value() : 80;
+        _dialServiceImpl->Locator(pluginInterface->Accessor());
 
         // Redirect all calls to the DIALServer, via a proxy.
-        pluginInterface->AddProxy(_dialPath, _dialPath, remote);
+        const string remote = (_dialURL.Host().Value() + (_T(":") + _dialURL.Port().Value()));
+        const string path = (_T("/") + _dialURL.Path().Value());
+        pluginInterface->AddProxy(path, path, remote);
 
         _adminLock.Unlock();
     }
@@ -680,8 +697,8 @@ namespace Plugin {
 
         _adminLock.Lock();
 
-        _dialServiceImpl->Locator(_dialURL.Text());
-        pluginInterface->RemoveProxy(_dialPath);
+        _dialServiceImpl->Locator(_dialURL);
+        pluginInterface->RemoveProxy(_T("/") + _dialURL.Path().Value());
 
         _adminLock.Unlock();
     }

--- a/DIALServer/DIALServer.h
+++ b/DIALServer/DIALServer.h
@@ -704,9 +704,9 @@ namespace Plugin {
             {
                 _text = Core::ToString(string("OUT: ") + response);
             }
-            Protocol(const string& response, const Core::URL* url)
+            Protocol(const string& response, const string& url)
             {
-                _text = Core::ToString(string("OUT: [") + url->Text() + "] " + response);
+                _text = Core::ToString(string("OUT: [") + url + "] " + response);
             }
             ~Protocol()
             {
@@ -754,45 +754,66 @@ namespace Plugin {
             DIALServerImpl& operator=(const DIALServerImpl&) = delete;
 
         public:
-            DIALServerImpl(const string& MACAddress, const string& baseURL, const string& appPath);
+            DIALServerImpl(const string& MACAddress, const Core::URL& baseURL, const string& appPath, const bool dynamicInterface);
             virtual ~DIALServerImpl();
 
         public:
             // Notification of a Partial Request received, time to attach a body..
-            virtual void LinkBody(Core::ProxyType<Web::Request>& element);
+            void LinkBody(Core::ProxyType<Web::Request>& element) override;
 
             // Notification of a Request received.
-            virtual void Received(Core::ProxyType<Web::Request>& text);
+            void Received(Core::ProxyType<Web::Request>& text) override;
 
             // Notification of a Response send.
-            virtual void Send(const Core::ProxyType<Web::Response>& text);
+            void Send(const Core::ProxyType<Web::Response>& text) override;
 
             // Notification of a channel state change..
-            virtual void StateChange();
+            void StateChange() override;
 
-            inline string URL() const
+            string URL() const
             {
-                string result;
-
-                _lock.Lock();
-
-                result = _baseURL + '/' + _appPath;
-
-                _lock.Unlock();
-
-                return (result);
+                Core::SafeSyncType<Core::CriticalSection> scopedLock(_lock);
+                return (_baseURL);
             }
-            inline void URL(Core::URL& locator) const
+            void Locator(const string& locator)
             {
-                locator = Core::URL(URL());
+                Locator(Core::URL(locator));
             }
-            inline void Locator(const string& hostName)
+            void Locator(const Core::URL& locator)
             {
                 _lock.Lock();
-
-                _baseURL = hostName;
-
+                if (_dynamicInterface == false) {
+                    _locator.Host(locator.Host().Value());
+                }
+                _locator.Port(locator.Port().Value());
+                UpdateURL();
                 _lock.Unlock();
+            }
+
+        private:
+            void Host(const uint32_t interface)
+            {
+                if ((_dynamicInterface == true) && (interface != static_cast<uint32_t>(~0))) {
+                    Core::AdapterIterator adapter(interface);
+                    if ((adapter.IsValid() == true)) {
+                        Core::IPV4AddressIterator addresses(adapter.IPV4Addresses());
+                        while (addresses.Next() == true) {
+                            Core::NodeId current(addresses.Address());
+                            if ((current.IsMulticast() == false) && (current.IsLocalInterface() == false)) {
+                                if (_locator.Host().Value() != current.HostAddress()) {
+                                    _locator.Host(current.HostAddress());
+                                    UpdateURL();
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            void UpdateURL()
+            {
+                _baseURL = (_locator.Text() + '/' + _appPath);
+                TRACE(Trace::Information, (_T("Updated base URL: %s"), URL().c_str()));
             }
 
         private:
@@ -800,8 +821,10 @@ namespace Plugin {
             // This should be the "Response" as depicted by the parent/DIALserver.
             Core::ProxyType<Web::Response> _response;
             std::list<Core::NodeId> _destinations;
+            Core::URL _locator;
             string _baseURL;
             const string _appPath;
+            bool _dynamicInterface;
         };
         class AppInformation {
         private:
@@ -1163,7 +1186,6 @@ namespace Plugin {
             , _service(NULL)
             , _dialURL()
             , _dialPath()
-            , _webServerPort()
             , _dialServiceImpl(NULL)
             , _deviceInfo(Core::ProxyType<Web::TextBody>::Create())
             , _sink(this)
@@ -1243,8 +1265,8 @@ namespace Plugin {
         void event_hide(const string& application);
         void event_show(const string& application);
 
-        const uint16_t WebServerPort() const {
-            return _webServerPort;
+        string BaseURL() const {
+            return (_dialServiceImpl->URL());
         }
 
         bool DeprecatedAPI() const {
@@ -1258,7 +1280,6 @@ namespace Plugin {
         PluginHost::IShell* _service;
         Core::URL _dialURL;
         string _dialPath;
-        uint16_t _webServerPort;
         DIALServerImpl* _dialServiceImpl;
         Core::ProxyType<Web::TextBody> _deviceInfo;
         Core::Sink<Notification> _sink;


### PR DESCRIPTION
If DIAL interface is set to 0.0.0.0 then the location IP for UPNP replies will be picked up from the interface the UPNP request was received on.