### PR TITLE
[DIAL] use uuid in USN

### DIFF
--- a/DIALServer/DIALServer.cpp
+++ b/DIALServer/DIALServer.cpp
@@ -117,7 +117,7 @@ namespace Plugin {
         return (Core::ERROR_NONE);
     }
 
-    DIALServer::DIALServerImpl::DIALServerImpl(const string& MACAddress, const Core::URL& locator, const string& appPath, const bool dynamicInterface)
+    DIALServer::DIALServerImpl::DIALServerImpl(const string& deviceId, const Core::URL& locator, const string& appPath, const bool dynamicInterface)
         : BaseClass(5, false, Core::NodeId(DialServerInterface.AnyInterface(), DialServerInterface.PortNumber()), DialServerInterface.AnyInterface(), 1024, 1024)
         , _response(Core::ProxyType<Web::Response>::Create())
         , _destinations()
@@ -131,11 +131,10 @@ namespace Plugin {
         _response->CacheControl = _T("max-age=1800");
         _response->Server = _T("Linux/2.6 UPnP/1.0 quick_ssdp/1.0");
         _response->ST = _SearchTarget;
-        _response->USN = _T("uuid:UniqueIdentifier::") + _SearchTarget;
+        _response->USN = _T("uuid:") + deviceId + _T("::") + _SearchTarget;
         // FIXME: Uncomment when adding WoL/WoWLAN support.
         // This SHALL NOT be present if neither WoL nor WoWLAN is supported.
-        // Moreover real MAC address of the network iface (either wired or wireless one) should be passed
-        // where currently Device identifier is passed in MACAddress.
+        // Moreover real MAC address of the network interface (either wired or wireless one) should be passed
         // _response->WakeUp = _T("MAC=") + MACAddress + _T(";Timeout=10");
         _response->Mode(Web::MARSHAL_UPPERCASE);
 


### PR DESCRIPTION
At the moment the USN is not unique and does not contain a unique identifier (guess it was an oversight not to replace the UniqueID string with an actual ID).
This PR add the uuid (device id) to the USN. According to this information it is even mandatory to use the uuid:

http://www.upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.0-20080424.pdf
" Note that the prefix of the USN header (before the double colon) must match the value of the UDN element in the device description. (The section on Description explains the UDN element.)"

https://williamboles.me/discovering-whats-out-there-with-ssdp/