### PR TITLE
[DIALServer] Only allow chaning port of locator URL from external source

### DIFF
--- a/DIALServer/DIALServer.h
+++ b/DIALServer/DIALServer.h
@@ -782,9 +782,6 @@ namespace Plugin {
             void Locator(const Core::URL& locator)
             {
                 _lock.Lock();
-                if (_dynamicInterface == false) {
-                    _locator.Host(locator.Host().Value());
-                }
                 _locator.Port(locator.Port().Value());
                 UpdateURL();
                 _lock.Unlock();


### PR DESCRIPTION
Only if binding interface is set to 0.0.0.0 it is possible to change the locator host to the one from the UPNP request, in other cases (i.e from WebServer) only port is updateable.