### PR TITLE
[METROL-297] Add automatic scanning upon connect/disconnect

### DIFF
--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -1540,13 +1540,6 @@ namespace WPASupplicant {
         {
             uint32_t result = Core::ERROR_UNKNOWN_KEY;
             
-            if(!IsScanning()){
-                Scan();
-            }
-
-            _isScanningCompleted.Lock();
-            _adminLock.Lock();
-
             EnabledContainer::iterator index(_enabled.find(SSID));
 
             if ((index != _enabled.end()) && (index->second.IsEnabled() == true)) {
@@ -1571,7 +1564,6 @@ namespace WPASupplicant {
                 _adminLock.Unlock();
             }
 
-            _isScanningCompleted.ResetEvent();
             return (result);
         }
 

--- a/WifiControl/WifiControl.cpp
+++ b/WifiControl/WifiControl.cpp
@@ -71,6 +71,7 @@ namespace Plugin
         } else {
             SYSLOG(Logging::Startup, ("Config directory %s doesn't exist and could not be created!\n", service->PersistentPath().c_str()));
         }
+        std::cerr << "\nCONFIG STORE: " << _configurationStore << std::endl;
 
         TRACE(Trace::Information, (_T("Starting the application for wifi called: [%s]"), config.Application.Value().c_str()));
 #ifdef USE_WIFI_HAL

--- a/WifiControl/WifiControlJsonRpc.cpp
+++ b/WifiControl/WifiControlJsonRpc.cpp
@@ -124,7 +124,6 @@ namespace Plugin {
     uint32_t WifiControl::endpoint_connect(const DeleteParamsInfo& params)
     {
         const string& ssid = params.Ssid.Value();
-
         return Connect(ssid);
     }
 


### PR DESCRIPTION
When there is a saved config of the Wifi, there is a chance that one can first scan networks (in which the saved network can not appear for some reason, maybe not in range), and after some time trying to connect to a wifi network that did not appear in searches. That will fail because connect method will not be able to get the BSSID of such a network. The user would need first to scan, and then try to connect to Wifi. 
I resolved this issue by first scanning for networks in the connect method. 