### PR TITLE
Development/bt scan

### DIFF
--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -1876,52 +1876,48 @@ protected:
                     result = Core::ERROR_REQUEST_SUBMITTED;
                 }
 
-                if (_parent->IsScanning() == false) {
-                    if (SetState(CONNECTING) == Core::ERROR_NONE) {
-                        if (IsConnected() == false) {
-                            if (IsBonded() == true) {
-                                BackgroundScan(false);
+                if (SetState(CONNECTING) == Core::ERROR_NONE) {
+                    if (IsConnected() == false) {
+                        if (IsBonded() == true) {
+                            BackgroundScan(false);
 
-                                Bluetooth::HCISocket::Command::Connect connect;
-                                connect.Clear();
-                                connect->bdaddr = *(Locator().Data());
-                                connect->pkt_type = htobs(HCI_DM1 | HCI_DM3 | HCI_DM5 | HCI_DH1 | HCI_DH3 | HCI_DH5);
-                                connect->pscan_rep_mode = 0x02;
-                                connect->clock_offset = 0x0000;
-                                connect->role_switch = 0x01;
+                            Bluetooth::HCISocket::Command::Connect connect;
+                            connect.Clear();
+                            connect->bdaddr = *(Locator().Data());
+                            connect->pkt_type = htobs(HCI_DM1 | HCI_DM3 | HCI_DM5 | HCI_DH1 | HCI_DH3 | HCI_DH5);
+                            connect->pscan_rep_mode = 0x02;
+                            connect->clock_offset = 0x0000;
+                            connect->role_switch = 0x01;
 
-                                result = _parent->Connector().Exchange(MAX_ACTION_TIMEOUT, connect, connect);
-                                if (result == Core::ERROR_NONE) {
-                                    if (connect.Result() == 0) {
-                                        Connection(btohs(connect.Response().handle));
-                                    } else {
-                                        TRACE(ControlFlow, (_T("Connect command failed [%d]"), connect.Result()));
-                                        AutoConnect(false);
-                                    }
+                            result = _parent->Connector().Exchange(MAX_ACTION_TIMEOUT, connect, connect);
+                            if (result == Core::ERROR_NONE) {
+                                if (connect.Result() == 0) {
+                                    Connection(btohs(connect.Response().handle));
                                 } else {
-                                    TRACE(Trace::Error, (_T("Failed to connect [%d]"), result));
-
-                                    if (result == Core::ERROR_TIMEDOUT) {
-                                        result = Core::ERROR_REQUEST_SUBMITTED;
-                                    } else {
-                                        AutoConnect(false);
-                                    }
+                                    TRACE(ControlFlow, (_T("Connect command failed [%d]"), connect.Result()));
+                                    AutoConnect(false);
                                 }
                             } else {
-                                result = Core::ERROR_ILLEGAL_STATE;
-                                TRACE(Trace::Error, (_T("Device not paired!")));
+                                TRACE(Trace::Error, (_T("Failed to connect [%d]"), result));
+
+                                if (result == Core::ERROR_TIMEDOUT) {
+                                    result = Core::ERROR_REQUEST_SUBMITTED;
+                                } else {
+                                    AutoConnect(false);
+                                }
                             }
                         } else {
-                            result = Core::ERROR_ALREADY_CONNECTED;
-                            TRACE(Trace::Error, (_T("Device already connected!")));
+                            result = Core::ERROR_ILLEGAL_STATE;
+                            TRACE(Trace::Error, (_T("Device not paired!")));
                         }
-
-                        ClearState(CONNECTING);
                     } else {
-                        TRACE(Trace::Information, (_T("Device is currently busy")));
+                        result = Core::ERROR_ALREADY_CONNECTED;
+                        TRACE(Trace::Error, (_T("Device already connected!")));
                     }
+
+                    ClearState(CONNECTING);
                 } else {
-                    TRACE(Trace::Information, (_T("Controller is currently busy scanning")));
+                    TRACE(Trace::Information, (_T("Device is currently busy")));
                 }
 
                 return (result);
@@ -2117,72 +2113,68 @@ protected:
                     result = Core::ERROR_REQUEST_SUBMITTED;
                 }
 
-                if (_parent->IsScanning() == false) {
-                    if (SetState(CONNECTING) == Core::ERROR_NONE) {
-                        if (IsConnected() == false) {
-                            if (IsBonded() == true) {
-                                BackgroundScan(false);
+                if (SetState(CONNECTING) == Core::ERROR_NONE) {
+                    if (IsConnected() == false) {
+                        if (IsBonded() == true) {
+                            BackgroundScan(false);
 
-                                Bluetooth::HCISocket::Command::ConnectLE connect;
-                                connect.Clear();
-                                connect->interval = htobs(0x0004);
-                                connect->window = htobs(0x0004);
-                                connect->initiator_filter = 0;
-                                connect->peer_bdaddr_type = LE_PUBLIC_ADDRESS;
-                                connect->peer_bdaddr = *(Locator().Data());
-                                connect->own_bdaddr_type = LE_PUBLIC_ADDRESS;
-                                connect->min_interval = htobs(0x000F);
-                                connect->max_interval = htobs(0x000F);
-                                connect->latency = htobs(0x0000);
-                                connect->supervision_timeout = htobs(8000/10); // in centiseconds
-                                connect->min_ce_length = htobs(0x0001);
-                                connect->max_ce_length = htobs(0x0001);
+                            Bluetooth::HCISocket::Command::ConnectLE connect;
+                            connect.Clear();
+                            connect->interval = htobs(0x0004);
+                            connect->window = htobs(0x0004);
+                            connect->initiator_filter = 0;
+                            connect->peer_bdaddr_type = LE_PUBLIC_ADDRESS;
+                            connect->peer_bdaddr = *(Locator().Data());
+                            connect->own_bdaddr_type = LE_PUBLIC_ADDRESS;
+                            connect->min_interval = htobs(0x000F);
+                            connect->max_interval = htobs(0x000F);
+                            connect->latency = htobs(0x0000);
+                            connect->supervision_timeout = htobs(8000/10); // in centiseconds
+                            connect->min_ce_length = htobs(0x0001);
+                            connect->max_ce_length = htobs(0x0001);
 
-                                result = Connector().Exchange(MAX_ACTION_TIMEOUT, connect, connect);
-                                if (result == Core::ERROR_NONE) {
-                                    if (connect.Result() == 0) {
-                                        Connection(btohs(connect.Response().handle));
-                                    } else {
-                                        TRACE(ControlFlow, (_T("ConnectLE command failed [%d]"), connect.Result()));
-                                        AutoConnect(false);
-                                    }
+                            result = Connector().Exchange(MAX_ACTION_TIMEOUT, connect, connect);
+                            if (result == Core::ERROR_NONE) {
+                                if (connect.Result() == 0) {
+                                    Connection(btohs(connect.Response().handle));
                                 } else {
-                                    TRACE(Trace::Error, (_T("Failed to connect [%d]"), result));
-
-                                    if (result == Core::ERROR_TIMEDOUT) {
-                                        // The device is not nearby or active, but we just whitelisted it, so keep searching...
-                                        Bluetooth::HCISocket::Command::ConnectLECancel connectCancel;
-                                        connectCancel.Clear();
-
-                                        result = Connector().Exchange(MAX_ACTION_TIMEOUT, connectCancel, connectCancel);
-                                        if ((result != Core::ERROR_NONE) || (connectCancel.Result() != 0)) {
-                                            TRACE(Trace::Error, (_T("Failed to cancel connection")));
-                                        } else if (connectCancel.Response() != 0) {
-                                            TRACE(Trace::Error, (_T("Controller failed to cancel connection (%i)"), connectCancel.Response()));
-                                        } else {
-                                            TRACE(Trace::Information, (_T("Canceled connection attempt")));
-                                        }
-
-                                        result = Core::ERROR_REQUEST_SUBMITTED;
-                                        BackgroundScan(true);
-                                    } else {
-                                        AutoConnect(false);
-                                    }
+                                    TRACE(ControlFlow, (_T("ConnectLE command failed [%d]"), connect.Result()));
+                                    AutoConnect(false);
                                 }
                             } else {
-                                result = Core::ERROR_ILLEGAL_STATE;
-                                TRACE(Trace::Error, (_T("Device is not paired")));
+                                TRACE(Trace::Error, (_T("Failed to connect [%d]"), result));
+
+                                if (result == Core::ERROR_TIMEDOUT) {
+                                    // The device is not nearby or active, but we just whitelisted it, so keep searching...
+                                    Bluetooth::HCISocket::Command::ConnectLECancel connectCancel;
+                                    connectCancel.Clear();
+
+                                    result = Connector().Exchange(MAX_ACTION_TIMEOUT, connectCancel, connectCancel);
+                                    if ((result != Core::ERROR_NONE) || (connectCancel.Result() != 0)) {
+                                        TRACE(Trace::Error, (_T("Failed to cancel connection")));
+                                    } else if (connectCancel.Response() != 0) {
+                                        TRACE(Trace::Error, (_T("Controller failed to cancel connection (%i)"), connectCancel.Response()));
+                                    } else {
+                                        TRACE(Trace::Information, (_T("Canceled connection attempt")));
+                                    }
+
+                                    result = Core::ERROR_REQUEST_SUBMITTED;
+                                    BackgroundScan(true);
+                                } else {
+                                    AutoConnect(false);
+                                }
                             }
                         } else {
-                            result = Core::ERROR_ALREADY_CONNECTED;
-                            TRACE(Trace::Error, (_T("Device is already connected!")));
+                            result = Core::ERROR_ILLEGAL_STATE;
+                            TRACE(Trace::Error, (_T("Device is not paired")));
                         }
-                        ClearState(CONNECTING);
                     } else {
-                        TRACE(Trace::Error, (_T("Device already connected!")));
+                        result = Core::ERROR_ALREADY_CONNECTED;
+                        TRACE(Trace::Error, (_T("Device is already connected!")));
                     }
+                    ClearState(CONNECTING);
                 } else {
-                    TRACE(Trace::Error, (_T("Controller is currently busy scanning")));
+                    TRACE(Trace::Error, (_T("Device is currently busy")));
                 }
 
                 return (result);

--- a/BluetoothControl/Tracing.h
+++ b/BluetoothControl/Tracing.h
@@ -290,17 +290,25 @@ namespace Plugin {
                     Format(_T("data=%s"), data.c_str());
                 }
             }
-            ControlFlow(const extended_inquiry_info& info)
+            ControlFlow(const inquiry_info& info)
             {
-                FORMAT_EVENT(EVT_EXTENDED_INQUIRY_RESULT, info.bdaddr);
-                Format(_T("dev_class=0x%06X, pscan_rep_mode=%d, pscan_period_mode=%d, clock_offset=%d, rssi=%d"),
-                       UnpackDeviceClass(info.dev_class), info.pscan_rep_mode, info.pscan_period_mode, btohs(info.clock_offset), info.rssi);
+                FORMAT_EVENT(EVT_INQUIRY_RESULT, info.bdaddr);
+                Format(_T("dev_class=0x%06X, pscan_rep_mode=%d, pscan_period_mode=%d, pscan_mode=%d, clock_offset=%d"),
+                       UnpackDeviceClass(info.dev_class), info.pscan_rep_mode, info.pscan_period_mode, info.pscan_mode, btohs(info.clock_offset));
             }
             ControlFlow(const inquiry_info_with_rssi& info)
             {
                 FORMAT_EVENT(EVT_INQUIRY_RESULT_WITH_RSSI, info.bdaddr);
                 Format(_T("dev_class=0x%06X, pscan_rep_mode=%d, pscan_period_mode=%d, clock_offset=%d, rssi=%d"),
                        UnpackDeviceClass(info.dev_class), info.pscan_rep_mode, info.pscan_period_mode, btohs(info.clock_offset), info.rssi);
+            }
+            ControlFlow(const extended_inquiry_info& info)
+            {
+                FORMAT_EVENT(EVT_EXTENDED_INQUIRY_RESULT, info.bdaddr);
+                string data;
+                Core::ToHexString(info.data, sizeof(info.data), data);
+                Format(_T("dev_class=0x%06X, pscan_rep_mode=%d, pscan_period_mode=%d, clock_offset=%d, rssi=%d, data=%s"),
+                       UnpackDeviceClass(info.dev_class), info.pscan_rep_mode, info.pscan_period_mode, btohs(info.clock_offset), info.rssi, data.c_str());
             }
             ControlFlow(const evt_conn_request& info)
             {


### PR DESCRIPTION
- Updates the implementation to IBluetooth interface changes (scan, abort scan, notifications),
- Fixes BT classic scanning (was broken, would pick up garbage),
- Fixes potential race when active scan is started at the same time when need for background scan is being evaluated,
- Removes restriction for not connecting when active scan is in progress -- seems not to bother the controller and allows the device to reconnect even if a scan is in progress.

Needs https://github.com/rdkcentral/Thunder/pull/638 and https://github.com/rdkcentral/ThunderInterfaces/pull/53.