### PR TITLE
[WiFi] On config change delete old config and store new one

### DIFF
--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -1396,7 +1396,6 @@ namespace WPASupplicant {
                 _adminLock.Unlock();
                 result = Config(Core::ProxyType<Controller>(*this), SSID);
 
-                // We have bo entry for this SSID, lets create one.
                 CustomRequest exchange(string(_TXT("REMOVE_NETWORK ")) + Core::NumberType<uint32_t>(entry->second.Id()).Text());
 
                 Submit(&exchange);

--- a/WifiControl/WifiControl.h
+++ b/WifiControl/WifiControl.h
@@ -693,6 +693,20 @@ namespace Plugin {
 
             return _controller->Disconnect(ssid);
         }
+
+        inline uint32_t UpdateStoredConfigList()
+        {   
+            uint32_t result = Core::ERROR_NONE;
+            Core::File configFile(_configurationStore);
+            if (configFile.Destroy()) {
+                result = Store();
+            } else {
+                result = Core::ERROR_UNAVAILABLE;
+            }
+
+            return result;
+        }
+
         inline uint32_t Store() {
             uint32_t result = Core::ERROR_NONE;
 

--- a/WifiControl/WifiControlJsonRpc.cpp
+++ b/WifiControl/WifiControlJsonRpc.cpp
@@ -88,10 +88,11 @@ namespace Plugin {
     // Method: delete - Forgets configuration of the specified network
     // Return codes:
     //  - ERROR_NONE: Success
+    //  - ERROR_UNAVAILABLE: Returned when unable to update config list stored on disk
     uint32_t WifiControl::endpoint_delete(const DeleteParamsInfo& params)
     {
         _controller->Destroy(params.Ssid.Value());
-        return Core::ERROR_NONE;
+        return UpdateStoredConfigList();
     }
 
     // Method: store - Stores the configurations in persistent storage


### PR DESCRIPTION
Currently modifying existing config is not available - changes are present only in the plugin, not on disk so they are lost on restart.