### PR TITLE
[Wifi] Fix Interface map being private

### DIFF
--- a/WifiControl/WifiControl.h
+++ b/WifiControl/WifiControl.h
@@ -743,7 +743,8 @@ namespace Plugin {
             }
             return result;
         }
-
+        
+    public:
         BEGIN_INTERFACE_MAP(WifiControl)
             INTERFACE_ENTRY(PluginHost::IPlugin)
             INTERFACE_ENTRY(PluginHost::IWeb)


### PR DESCRIPTION
This currently breaks the build therefore foxing in place