### PR TITLE
IOConnector: Fix and rework to enable the use of the TimedPin 

### DIFF
--- a/IOConnector/GPIO.cpp
+++ b/IOConnector/GPIO.cpp
@@ -290,7 +290,7 @@ namespace GPIO
     }
 
     void Pin::Unregister(IInputPin::INotification* sink) /* override */ {
-        _timedPin.Register(sink);
+        _timedPin.Unregister(sink);
     }
 
     void Pin::AddMarker(const uint32_t marker) /* override */ {

--- a/IOConnector/GPIO.cpp
+++ b/IOConnector/GPIO.cpp
@@ -172,7 +172,7 @@ namespace GPIO
             // force HasChanged to be true!!
             _lastValue = !Get();
 
-            Updated();
+            Evaluate();
         }
     }
 

--- a/IOConnector/GPIO.h
+++ b/IOConnector/GPIO.h
@@ -121,7 +121,8 @@ namespace GPIO {
 
                     ASSERT(_marker == static_cast<uint32_t>(~0));
                     _marker = marker;
-                    _parent.Updated();
+                    Core::IWorkerPool::Instance().Submit(_job);
+
                     _parent.Unlock();
                 }
             }

--- a/IOConnector/IOConnector.cpp
+++ b/IOConnector/IOConnector.cpp
@@ -211,7 +211,7 @@ namespace Plugin
         return (_pins.size() > 0 ? string() : _T("Could not instantiate the requested Pin"));
     }
 
-    /* virtual */ void IOConnector::Register(ICatalog::INotification* sink)
+    /* virtual */ void IOConnector::Register(Exchange::IExternal::ICatalog::INotification* sink)
     {
         _adminLock.Lock();
 
@@ -229,7 +229,7 @@ namespace Plugin
         _adminLock.Unlock();
     }
 
-    /* virtual */ void IOConnector::Unregister(ICatalog::INotification* sink)
+    /* virtual */ void IOConnector::Unregister(Exchange::IExternal::ICatalog::INotification* sink)
     {
         _adminLock.Lock();
 
@@ -248,6 +248,20 @@ namespace Plugin
     /* virtual */ Exchange::IExternal* IOConnector::Resource(const uint32_t id)
     {
         Exchange::IExternal* result = nullptr;
+
+        Pins::iterator index = _pins.find(id);
+
+        if (index != _pins.end()) {
+            result = index->second.Pin();
+            result->AddRef();
+        }
+
+        return (result);
+    }
+
+    /* virtual */ Exchange::IInputPin* IOConnector::IInputPinResource(const uint32_t id)
+    {
+        Exchange::IInputPin* result = nullptr;
 
         Pins::iterator index = _pins.find(id);
 

--- a/IOConnector/IOConnector.h
+++ b/IOConnector/IOConnector.h
@@ -33,7 +33,8 @@ namespace Plugin {
         : public PluginHost::IPlugin,
           public PluginHost::IWeb,
           public Exchange::IExternal::ICatalog,
-          public PluginHost::JSONRPC {
+          public PluginHost::JSONRPC,
+          public Exchange::IInputPin::ICatalog {
     private:
         class Sink : public Exchange::IExternal::INotification {
         public:
@@ -283,6 +284,7 @@ namespace Plugin {
         INTERFACE_ENTRY(PluginHost::IWeb)
         INTERFACE_ENTRY(Exchange::IExternal::ICatalog)
         INTERFACE_ENTRY(PluginHost::IDispatcher)
+        INTERFACE_ENTRY(Exchange::IInputPin::ICatalog)
         END_INTERFACE_MAP
 
     public:
@@ -294,9 +296,10 @@ namespace Plugin {
 
         //   IExternal::IFactory methods
         // -------------------------------------------------------------------------------------------------------
-        void Register(ICatalog::INotification* sink) override;
-        void Unregister(ICatalog::INotification* sink) override;
+        void Register(Exchange::IExternal::ICatalog::INotification* sink) override;
+        void Unregister(Exchange::IExternal::ICatalog::INotification* sink) override;
         Exchange::IExternal* Resource(const uint32_t id) override;
+        Exchange::IInputPin* IInputPinResource(const uint32_t id) override;
 
         //  IWeb methods
         // -------------------------------------------------------------------------------------------------------

--- a/IOConnector/TimedInput.h
+++ b/IOConnector/TimedInput.h
@@ -54,9 +54,7 @@ namespace GPIO {
             if (index == _markers.end()) {
                 _markers.push_back(marker);
             }
-            else {
-                // Do not set the same marker twice!!!
-                ASSERT (marker != *index);
+            else if (marker != *index) {
                 _markers.insert(index, marker);
             }
         }


### PR DESCRIPTION
This PR implements some fixes and rework to enable the use of the GPIO::Pin::TimedPin to correctly manage markers and notify observers.

It depends on https://github.com/rdkcentral/ThunderInterfaces/pull/112