### PR TITLE
[BluetoothControl] Make the LE connect not block audio output

### DIFF
--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -2130,8 +2130,8 @@ protected:
 
                             Bluetooth::HCISocket::Command::ConnectLE connect;
                             connect.Clear();
-                            connect->interval = htobs(0x0004);
-                            connect->window = htobs(0x0004);
+                            connect->interval = htobs(4*0x0010);
+                            connect->window = htobs(0x0010); // Have some back off time, so the connection does not hog the link layer completely.
                             connect->initiator_filter = 0;
                             connect->peer_bdaddr_type = LE_PUBLIC_ADDRESS;
                             connect->peer_bdaddr = *(Locator().Data());


### PR DESCRIPTION
Punch a hole in the scanning operation done by LE connect command, so simultaneous high bandwidth transfer (like audio streaming) is not clogged. 

This doesn't seem to have a negative impact on BT remote control connection or re-connection, but leaves enough link layer time for the audio stream to come through without stuttering.