### PR TITLE
[WORKERPOOL] Schedule method on JobType's is obsolete.

### DIFF
--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -442,12 +442,12 @@ namespace Plugin {
                 _retries = 0;
                 _job.Revoke();
                 if ( (_offers.size() > 0) && (_offers.front().Address() == preferred) ) {
-                    _job.Schedule(Core::Time::Now().Add(AckWaitTimeout));
+                    _job.Reschedule(Core::Time::Now().Add(AckWaitTimeout));
                     result = _client.Request(_offers.front());
                 }
                 else {
                     ClearLease();
-                    _job.Schedule(Core::Time::Now().Add(_handleTime));
+                    _job.Reschedule(Core::Time::Now().Add(_handleTime));
                     result = _client.Discover();
                 }
 
@@ -474,12 +474,12 @@ namespace Plugin {
                             _retries = 0;
                             ClearLease();
                             _client.Discover();
-                            _job.Schedule(Core::Time::Now().Add(_handleTime));
+                            _job.Reschedule(Core::Time::Now().Add(_handleTime));
                         }
                         else {
                             // Start refreshing the Lease..
                             _client.Request(_client.Lease());
-                            _job.Schedule(Core::Time::Now().Add(AckWaitTimeout));
+                            _job.Reschedule(Core::Time::Now().Add(AckWaitTimeout));
                         }
                     }
                     else {
@@ -491,7 +491,7 @@ namespace Plugin {
                             _client.Close();
                         }
                         _retries = 0;
-                        _job.Schedule(_client.Expired());
+                        _job.Reschedule(_client.Expired());
                     }
                 }
                 else if (_offers.size() == 0) {
@@ -499,7 +499,7 @@ namespace Plugin {
                     if (_retries++ < _maxRetries) {
                         ClearLease();
                         _client.Discover();
-                        _job.Schedule(Core::Time::Now().Add(_handleTime));
+                        _job.Reschedule(Core::Time::Now().Add(_handleTime));
                     }
                     else {
                         _client.Close();
@@ -509,7 +509,7 @@ namespace Plugin {
                 else if ( (_client.Lease() == _offers.front()) && (_retries++ < _maxRetries) ) {
                     // Looks like the acknwledge did not get a reply, should we retry ?
                     _client.Request(_client.Lease());
-                    _job.Schedule(Core::Time::Now().Add(AckWaitTimeout));
+                    _job.Reschedule(Core::Time::Now().Add(AckWaitTimeout));
                 }
                 else {
                     // Request retries expired or Request rejected
@@ -521,7 +521,7 @@ namespace Plugin {
                     if (_offers.size() == 0) {
                         // There is no valid offer, so request for new offer
                         _retries = 0;
-                        _job.Schedule(Core::Time::Now().Add(_handleTime));
+                        _job.Reschedule(Core::Time::Now().Add(_handleTime));
                     }
                     else {
                         DHCPClient::Offer& node (_offers.front());
@@ -532,7 +532,7 @@ namespace Plugin {
                         // Seems we have some offers pending and we are not Active yet, request an ACK
                         _client.Request(node);
                         _retries = 0;
-                        _job.Schedule(Core::Time::Now().Add(AckWaitTimeout));
+                        _job.Reschedule(Core::Time::Now().Add(AckWaitTimeout));
                     }
                 }
             }

--- a/WifiControl/WifiControl.cpp
+++ b/WifiControl/WifiControl.cpp
@@ -509,7 +509,9 @@ namespace Plugin
             event_networkchange();
             break;
         }
-
+        case WPASupplicant::Controller::WPS_EVENT_SUCCESS: {
+            break;
+        }
         case WPASupplicant::Controller::WPS_EVENT_CRED_RECEIVED: {
             _wpsConnect.Completed(Core::ERROR_NONE);
             break;

--- a/WifiControl/WifiControl.h
+++ b/WifiControl/WifiControl.h
@@ -232,7 +232,7 @@ namespace Plugin {
                 MoveState (states::SCANNING);
 
                 _controller->Scan();
-                _job.Schedule(Core::Time::Now().Add(_interval));
+                _job.Reschedule(Core::Time::Now().Add(_interval));
 
                 return Core::ERROR_NONE;
             }
@@ -284,7 +284,7 @@ namespace Plugin {
                 if (_state == states::SCANNING) {
                     // Seems that the Scan did not complete in time. Lets reschedule for later...
                     _state = states::RETRY;
-                    _job.Schedule(Core::Time::Now().Add(_interval));
+                    _job.Reschedule(Core::Time::Now().Add(_interval));
                 }
                 else if (_state == states::SCANNED) {
 
@@ -321,7 +321,7 @@ namespace Plugin {
                         _controller->Connect(this, _ssidList.front().SSID(), _ssidList.front().BSSID());
                     }
 
-                    _job.Schedule(Core::Time::Now().Add(_interval));
+                    _job.Reschedule(Core::Time::Now().Add(_interval));
                 }
                 else if (_state == states::CONNECTING) {
                     // If we sre still in the CONNECTING mode, it must mean that previous CONNECT Failed
@@ -336,7 +336,7 @@ namespace Plugin {
                     else {
                         _controller->Connect(this, _ssidList.front().SSID(), _ssidList.front().BSSID());
                     }
-                    _job.Schedule(Core::Time::Now().Add(_interval));
+                    _job.Reschedule(Core::Time::Now().Add(_interval));
                 }
                 else if (_state == states::RETRY) {
                     if (_attempts == 0) {
@@ -349,7 +349,7 @@ namespace Plugin {
                         _state = states::SCANNING;
                         _controller->Scan();
 
-                        _job.Schedule(Core::Time::Now().Add(_interval));
+                        _job.Reschedule(Core::Time::Now().Add(_interval));
                     }
                 }
 
@@ -462,7 +462,7 @@ namespace Plugin {
                 if(result == Core::ERROR_NONE) {
                     _ssid = ssid;
                     _state = states::REQUESTED;
-                    _job.Schedule(Core::Time::Now().Add(walkTime * 1000));
+                    _job.Reschedule(Core::Time::Now().Add(walkTime * 1000));
                 }
                 _adminLock.Unlock();
                 return result;

--- a/examples/OutOfProcessPlugin/OutOfProcessImplementation.cpp
+++ b/examples/OutOfProcessPlugin/OutOfProcessImplementation.cpp
@@ -251,7 +251,7 @@ namespace Plugin {
             , _fps(0)
             , _hidden(false)
             , _dispatcher()
-            , _executor(1, 0, 4, &_dispatcher)
+            , _executor(1, 0, 4, &_dispatcher, nullptr)
             , _sink(*this)
             , _service(nullptr)
             , _engine()

--- a/examples/SimpleCOMRPCPluginServer/SimpleCOMRPCPluginServer.h
+++ b/examples/SimpleCOMRPCPluginServer/SimpleCOMRPCPluginServer.h
@@ -252,7 +252,7 @@ namespace Plugin {
                 } while (nextSlot < timeSlot);
 
                 if (nextSlot != static_cast<uint64_t>(~0)) {
-                    _job.Schedule(Core::Time(nextSlot));
+                    _job.Reschedule(Core::Time(nextSlot));
                 }
 
                 _adminLock.Unlock();


### PR DESCRIPTION
Jobs have now a more eleborated state, so the use of schedule is now
misleading as in the same time someone might have scheduled or submitted
it, the reschedule is mroe expected than a schedule. So lets change all
Schedules -> Reschedule.