### PR TITLE
RemoteControl: Fix potential deadlock

### DIFF
--- a/RemoteControl/RemoteControl.cpp
+++ b/RemoteControl/RemoteControl.cpp
@@ -838,8 +838,10 @@ namespace Plugin {
         _eventLock.Lock();
 
         //Make sure a sink is not registered multiple times.
-        if (std::find(_notificationClients.begin(), _notificationClients.end(), sink) != _notificationClients.end())
+        if (std::find(_notificationClients.begin(), _notificationClients.end(), sink) != _notificationClients.end()) {
+            _eventLock.Unlock();
             return;
+        }
 
         TRACE(Trace::Information , (_T("Registered a client with RemoteControl")));
         _notificationClients.push_back(sink);
@@ -855,8 +857,10 @@ namespace Plugin {
         std::list<Exchange::IRemoteControl::INotification*>::iterator index(std::find(_notificationClients.begin(), _notificationClients.end(), sink));
 
         // Make sure you do not unregister something you did not register !!!
-        if (index == _notificationClients.end())
+        if (index == _notificationClients.end()) {
+            _eventLock.Unlock();
             return;
+        }
 
         if (index != _notificationClients.end()) {
             (*index)->Release();


### PR DESCRIPTION
Fixing potential deadlock when registering/unregistering for events, where if notification client is already listed/non-existing it would leave the Core::CriticalSection _eventLock in permanent lock state, thus locking all event notifications.