### PR TITLE
IOConnector: Handle key release without key press scenario

### DIFF
--- a/IOConnector/TimedInput.h
+++ b/IOConnector/TimedInput.h
@@ -76,8 +76,15 @@ namespace GPIO {
 
             if (pressed == true) {
                 _pressedTime = now;
+                return (reached);
             }
-            else if ((_markers.size() != 0) && (now > (_pressedTime + BounceThreshold))) {
+
+            if (_pressedTime == 0) {
+                TRACE(Trace::Error, (_T("Detected key release without key press")));
+                return (reached);
+            }
+
+            if ((_markers.size() != 0) && (now > (_pressedTime + BounceThreshold))) {
                 uint32_t elapsedTime = static_cast<uint32_t>( (now - _pressedTime) / Core::Time::TicksPerMillisecond );
 
                 // See which marker we have reached..
@@ -88,6 +95,7 @@ namespace GPIO {
                     reached = true;
                 }
             }
+            _pressedTime = 0;
 
             return(reached);
         }

--- a/IOConnector/TimedInput.h
+++ b/IOConnector/TimedInput.h
@@ -77,10 +77,7 @@ namespace GPIO {
             if (pressed == true) {
                 _pressedTime = now;
             }
-            else if (_markers.size() == 0) {
-                reached = true;
-            } 
-            else if (now > (_pressedTime + BounceThreshold)) {
+            else if ((_markers.size() != 0) && (now > (_pressedTime + BounceThreshold))) {
                 uint32_t elapsedTime = static_cast<uint32_t>( (now - _pressedTime) / Core::Time::TicksPerMillisecond );
 
                 // See which marker we have reached..
@@ -88,10 +85,8 @@ namespace GPIO {
                 while ( (index != _markers.cend()) && (elapsedTime > *index)) {
                     marker = *index;
                     index++;
+                    reached = true;
                 }
-
-                // Now we know which marker we have reached, report it.
-                reached = (index != _markers.cend());
             }
 
             return(reached);


### PR DESCRIPTION
This PR brings in the below commits

5c1c8d9a58421d87986af34890972139e3a3afd9 : Fix issue where notification is not sent for last marker in list
e57cb3c2a150d0213b7d1230c088260aca2df722 : Handle key release without key press scenario