### PR TITLE
Making sure that failing WifiControl plugin won't break Thunder

### DIFF
--- a/WifiControl/WifiControlImplementation.cpp
+++ b/WifiControl/WifiControlImplementation.cpp
@@ -871,12 +871,13 @@ namespace Plugin
         {
 #ifndef USE_WIFI_HAL
 
-            _autoConnect.Revoke();
-            _wpsConnect.Revoke();
-            _controller->Callback(nullptr);
-            _controller->Terminate();
-            _controller.Release();
-
+            if (_controller.IsValid()) {
+                _autoConnect.Revoke();
+                _wpsConnect.Revoke();
+                _controller->Callback(nullptr);
+                _controller->Terminate();
+                _controller.Release();
+            }
             _wpaSupplicant.Terminate();
 #endif
             _job.Revoke();


### PR DESCRIPTION
This issue was only present when trying to run Thunder with WifiControl plugin enabled on devices without a wireless network card, so for example on Ubuntu VM with NAT. In this case, it is not possible to enable wpa_supplicant on a proper interface (since the wireless network card is not there), so the plugin fails to initialize, and then it crushes Thunder in Debug mode when an assert fires. It is now fixed with a simple conditional statement.