### PR TITLE
[BluetoothControl] Don't assert on failed adapter init

### DIFF
--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -3565,6 +3565,10 @@ protected:
         {
             return (_application);
         }
+        const ControlSocket& Connector() const
+        {
+            return (_application);
+        }
         void Update()
         {
             _adminLock.Lock();


### PR DESCRIPTION
Since it often happens on Pi, don't crash because of this.
[Options:-DPLUGIN_CECCONTROL=OFF]