### PR TITLE
[NetworkControl] MAC control dynamically..

### DIFF
--- a/NetworkControl/DHCPClient.h
+++ b/NetworkControl/DHCPClient.h
@@ -38,6 +38,7 @@ namespace Plugin {
             CLASSIFICATION_RELEASE = 7,
             CLASSIFICATION_INFORM = 8,
         };
+        using NameServers = std::vector<Core::NodeId>;
 
     private:
         using UDPv4Frame = Core::UDPv4FrameType<1024>;
@@ -110,6 +111,8 @@ namespace Plugin {
 
 
     public:
+        static constexpr uint8_t MACSize = UDPv4Frame::MACSize;
+
         // DHCP constants (see RFC 2131 section 4.1)
         static constexpr uint16_t DefaultDHCPServerPort = 67;
         static constexpr uint16_t DefaultDHCPClientPort = 68;
@@ -234,7 +237,7 @@ namespace Plugin {
             Core::OptionalType<uint8_t> messageType;
             Core::NodeId gateway; /* the IP address that was offered to us */
             Core::NodeId broadcast; /* the IP address that was offered to us */
-            std::list<Core::NodeId> dns; /* the IP address that was offered to us */
+            NameServers dns; /* the IP address that was offered to us */
             Core::OptionalType<uint8_t> netmask;
             Core::OptionalType<uint32_t> leaseTime; /* lease time in seconds */
             Core::OptionalType<uint32_t> renewalTime; /* renewal time in seconds */
@@ -277,7 +280,7 @@ namespace Plugin {
 
                 Update(options);
             }
-            Offer(const Core::NodeId& source, const Core::NodeId& offer, const uint8_t netmask, const Core::NodeId& gateway, const Core::NodeId& broadcast, const uint32_t xid, std::list<Core::NodeId>&& dns)
+            Offer(const Core::NodeId& source, const Core::NodeId& offer, const uint8_t netmask, const Core::NodeId& gateway, const Core::NodeId& broadcast, const uint32_t xid, NameServers&& dns)
                 : _source(source)
                 , _offer(offer)
                 , _gateway(gateway)
@@ -428,7 +431,7 @@ namespace Plugin {
             {
                 return (_gateway);
             }
-            const std::list<Core::NodeId>& DNS() const
+            const NameServers& DNS() const
             {
                 return (_dns);
             }
@@ -466,7 +469,7 @@ namespace Plugin {
             Core::NodeId _offer; /* the IP address that was offered to us */
             Core::NodeId _gateway; /* the IP address that was offered to us */
             Core::NodeId _broadcast; /* the IP address that was offered to us */
-            std::list<Core::NodeId> _dns; /* the IP address that was offered to us */
+            NameServers _dns; /* the IP address that was offered to us */
             uint8_t _netmask;
             uint32_t _xid;
             uint32_t _leaseTime; /* lease time in seconds */
@@ -508,6 +511,14 @@ namespace Plugin {
         void UpdateMAC(const uint8_t buffer[], const uint8_t size VARIABLE_IS_NOT_USED) {
             ASSERT(size == _udpFrame.MACSize);
             _udpFrame.SourceMAC(buffer);
+        }
+        uint8_t MAC(uint8_t buffer[], const uint8_t size) const {
+            uint8_t loaded = 0;
+            if (_udpFrame.IsBroadcastMAC(_udpFrame.SourceMAC()) == false) {
+                loaded = std::min(size, _udpFrame.MACSize);
+                memcpy(buffer, _udpFrame.SourceMAC(), loaded);
+            }
+            return (loaded);
         }
         /* Ask DHCP servers for offers. */
         inline uint32_t Discover()

--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -50,8 +50,8 @@ namespace Plugin
         , _connectionId(0)
         , _service(nullptr)
         , _networkControl()
-        , _connectionNotification(this)
-        , _networkNotification(this)
+        , _connectionNotification(*this)
+        , _networkNotification(*this)
     {
     }
 

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef PLUGIN_NETWORKCONTROL_H
-#define PLUGIN_NETWORKCONTROL_H
+#pragma once
 
 #include "Module.h"
 #include "DHCPClient.h"
@@ -37,13 +36,14 @@ namespace Plugin {
         class ConnectionNotification : public RPC::IRemoteConnection::INotification {
         public:
             ConnectionNotification() = delete;
+            ConnectionNotification(ConnectionNotification&&) = delete;
             ConnectionNotification(const ConnectionNotification&) = delete;
+            ConnectionNotification& operator=(ConnectionNotification&&) = delete;
             ConnectionNotification& operator=(const ConnectionNotification&) = delete;
 
-            explicit ConnectionNotification(NetworkControl* parent)
-                : _parent(*parent)
+            explicit ConnectionNotification(NetworkControl& parent)
+                : _parent(parent)
             {
-                ASSERT(parent != nullptr);
             }
             ~ConnectionNotification() override = default;
 
@@ -69,20 +69,19 @@ namespace Plugin {
 
         class NetworkNotification : public Exchange::INetworkControl::INotification {
         public:
-            explicit NetworkNotification(NetworkControl* parent)
-                : _parent(*parent)
-            {
-                ASSERT(parent != nullptr);
-            }
-
-            ~NetworkNotification() override
-            {
-            }
-
             NetworkNotification() = delete;
+            NetworkNotification(NetworkNotification&&) = delete;
             NetworkNotification(const NetworkNotification&) = delete;
+            NetworkNotification& operator=(NetworkNotification&&) = delete;
             NetworkNotification& operator=(const NetworkNotification&) = delete;
 
+            explicit NetworkNotification(NetworkControl& parent)
+                : _parent(parent)
+            {
+            }
+            ~NetworkNotification() override = default;
+
+        public:
             void Update(const string& interface) override
             {
                 Exchange::JNetworkControl::Event::Update(_parent, interface);
@@ -99,21 +98,26 @@ namespace Plugin {
     public:
         class StatusData : public Core::JSON::Container {
         public:
+            StatusData(StatusData&&) = delete;
+            StatusData(const StatusData&) = delete;
+            StatusData& operator=(StatusData&&) = delete;
+            StatusData& operator=(const StatusData&) = delete;
+
             StatusData()
                 : Core::JSON::Container()
             {
                 Add(_T("statustype"), &StatusType);
             }
-
-            StatusData(const StatusData&) = delete;
-            StatusData& operator=(const StatusData&) = delete;
+            ~StatusData() override = default;
 
         public:
             Core::JSON::EnumType<Exchange::INetworkControl::StatusType> StatusType;
         };
 
     public:
+        NetworkControl(NetworkControl&&) = delete;
         NetworkControl(const NetworkControl&) = delete;
+        NetworkControl& operator=(NetworkControl&&) = delete;
         NetworkControl& operator=(const NetworkControl&) = delete;
 
         NetworkControl();
@@ -155,5 +159,3 @@ namespace Plugin {
     };
 } // namespace Plugin
 } // namespace WPEFramework
-
-#endif // PLUGIN_NETWORKCONTROL_H

--- a/NetworkControl/NetworkControlImplementation.cpp
+++ b/NetworkControl/NetworkControlImplementation.cpp
@@ -29,11 +29,9 @@ namespace Plugin
     class NetworkControlImplementation : public Exchange::INetworkControl,
                                          public Exchange::IConfiguration {
 
-        static constexpr const TCHAR* NameServer = _T("nameserver ");
-        using StringList = RPC::IteratorType<Exchange::INetworkControl::IStringIterator>;
-        using NetworkInfoIteratorImplementation = RPC::IteratorType<Exchange::INetworkControl::INetworkInfoIterator>;
-
     public:
+        using NameServers = DHCPClient::NameServers;
+
         class Entry : public Core::JSON::Container {
         public:
             Entry& operator=(Entry&&) = delete;
@@ -187,8 +185,6 @@ namespace Plugin
         };
 
     private:
-        using Store = Core::JSON::ArrayType<Entry>;
-
         class Settings {
         public:
             Settings& operator= (const Settings& rhs) = delete;
@@ -314,16 +310,18 @@ namespace Plugin
             Core::IPNode _address;
             Core::NodeId _gateway;
             Core::NodeId _broadcast;
-            std::list<Core::NodeId> _dns;
+            NameServers _dns;
         };
 
         class AdapterObserver : public WPEFramework::Core::AdapterObserver::INotification {
         public:
             AdapterObserver() = delete;
+            AdapterObserver(AdapterObserver&&) = delete;
             AdapterObserver(const AdapterObserver&) = delete;
+            AdapterObserver& operator=(AdapterObserver&&) = delete;
             AdapterObserver& operator=(const AdapterObserver&) = delete;
 
-PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
+            PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
             AdapterObserver(NetworkControlImplementation& parent)
                 : _parent(parent)
                 , _adminLock()
@@ -332,7 +330,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
                 , _job(*this)
             {
             }
-POP_WARNING()
+            POP_WARNING()
             ~AdapterObserver() override = default;
 
         public:
@@ -353,7 +351,7 @@ POP_WARNING()
                 _job.Revoke();
             }
  
-            virtual void Event(const string& interface) override
+            void Event(const string& interface) override
             {
                 _adminLock.Lock();
 
@@ -427,18 +425,19 @@ POP_WARNING()
             Core::JSON::Boolean Open;
         };
 
-
         class DHCPEngine : private DHCPClient::ICallback {
         private:
             static constexpr uint32_t AckWaitTimeout = 1000; // 1 second is a life time for a server to respond!
 
         public:
             DHCPEngine() = delete;
+            DHCPEngine(DHCPEngine&&) = delete;
             DHCPEngine(const DHCPEngine&) = delete;
+            DHCPEngine& operator=(DHCPEngine&&) = delete;
             DHCPEngine& operator=(const DHCPEngine&) = delete;
 
-PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
-             DHCPEngine(NetworkControlImplementation& parent, const string& interfaceName, const uint8_t waitTimeSeconds, const uint8_t maxRetries, const Entry& info)
+            PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
+            DHCPEngine(NetworkControlImplementation& parent, const string& interfaceName, const uint8_t waitTimeSeconds, const uint8_t maxRetries, const Entry& info)
                 : _parent(parent)
                 , _retries(0)
                 , _maxRetries(maxRetries)
@@ -454,7 +453,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
 
                     if (source.IsValid() == true) {
                         // Extract the DNS that where associated with this DHCP..
-                        std::list<Core::NodeId> dns;
+                        NameServers dns;
 
                         Core::JSON::ArrayType<Core::JSON::String>::ConstIterator entries(info.DNS.Elements());
 
@@ -470,7 +469,7 @@ PUSH_WARNING(DISABLE_WARNING_THIS_IN_MEMBER_INITIALIZER_LIST)
                     }
                 }
             }
-POP_WARNING()
+            POP_WARNING()
            ~DHCPEngine() = default;
 
         public:
@@ -577,7 +576,7 @@ POP_WARNING()
             const Settings& Info() const {
                 return (_settings);
             }
-            const std::list<Core::NodeId>& DNS() const {
+            const NameServers& DNS() const {
                 return (_client.Lease().DNS());
             }
             bool HasActiveLease() const {
@@ -585,8 +584,16 @@ POP_WARNING()
             }
             void Get(Entry& info) const
             {
+                uint8_t mac[DHCPClient::MACSize];
+               
                 info.Mode = _settings.Mode();
                 info.Interface = _client.Interface();
+                if (_client.MAC(mac, sizeof(mac)) == DHCPClient::MACSize) {
+                    string macString;
+                    Core::ToHexString(mac, DHCPClient::MACSize, macString, ':');
+                    info.MAC = macString;
+                }
+
                 if (_client.HasActiveLease() == true) {
                     if (_settings.Address().IsValid() == true) {
                         info.Address = _settings.Address().HostAddress();
@@ -646,11 +653,21 @@ POP_WARNING()
             Core::WorkerPool::JobType<DHCPEngine&> _job;
             Settings _settings;
         };
-        using DHCPEngineList = std::list<DHCPEngine>;
+
+        using Store = Core::JSON::ArrayType<Entry>;
+        using NetworkConfigs = std::unordered_map<string, Entry>;
+        using RequiredSets = std::vector<string>;
+        using Networks = std::unordered_map<string, DHCPEngine>;
+        using Notifications = std::vector<Exchange::INetworkControl::INotification*>;
+        using StringList = RPC::IteratorType<Exchange::INetworkControl::IStringIterator>;
+        using NetworkInfoIteratorImplementation = RPC::IteratorType<Exchange::INetworkControl::INetworkInfoIterator>;
 
     public:
+        NetworkControlImplementation(NetworkControlImplementation&&) = delete;
         NetworkControlImplementation(const NetworkControlImplementation&) = delete;
+        NetworkControlImplementation& operator= (NetworkControlImplementation&&) = delete;
         NetworkControlImplementation& operator= (const NetworkControlImplementation&) = delete;
+
         NetworkControlImplementation()
             : _adminLock()
             , _config()
@@ -679,6 +696,7 @@ POP_WARNING()
             }
         }
 
+    public:
         uint32_t Register(Exchange::INetworkControl::INotification* notification) override
         {
             ASSERT(notification);
@@ -770,15 +788,8 @@ POP_WARNING()
                     if (hardware.IsValid() == false) {
                         SYSLOG(Logging::Startup, (_T("Interface [%s], not available"), interfaceName.c_str()));
                     } else {
-                        DHCPEngine& engine = AddInterface(interfaceName, index.Current());
+                        DHCPEngine& engine = AddInterface(hardware, index.Current());
                         if (hardware.IsUp() == false) {
-                            if (index.Current().MAC.IsSet() == true) {
-                                uint8_t buffer[6];
-                                Core::FromHexString(index.Current().MAC.Value(), buffer, sizeof(buffer), ':');
-                                if (hardware.MACAddress(buffer) != Core::ERROR_NONE) {
-                                    SYSLOG(Logging::Startup, (_T("Interface [%s], could not set requested MAC address"), interfaceName.c_str()));
-                                }
-                            }
                             hardware.Up(true);
                         } else {
                             Reload(interfaceName, (engine.Info().Mode() == Exchange::INetworkControl::ModeType::DYNAMIC));
@@ -868,7 +879,7 @@ POP_WARNING()
             _adminLock.Lock();
             if (interface.empty() != true) {
 
-                std::map<const string, DHCPEngine>::iterator entry(_dhcpInterfaces.find(interface));
+                Networks::iterator entry(_dhcpInterfaces.find(interface));
                 if (entry != _dhcpInterfaces.end()) {
                     Core::AdapterIterator adapter(entry->first);
                     if (adapter.IsValid() == true) {
@@ -890,7 +901,7 @@ POP_WARNING()
             _adminLock.Lock();
 
             if (interface.empty() != true) {
-                std::map<const string, DHCPEngine>::iterator entry(_dhcpInterfaces.find(interface));
+                Networks::iterator entry(_dhcpInterfaces.find(interface));
                 if (entry != _dhcpInterfaces.end()) {
                     if (entry->second.Info().Mode() == Exchange::INetworkControl::ModeType::STATIC) {
                         result = Reload(entry->first, false);
@@ -942,7 +953,7 @@ POP_WARNING()
         uint32_t DNS(Exchange::INetworkControl::IStringIterator*& dns) const override
         {
             uint32_t result = Core::ERROR_UNAVAILABLE;
-            std::list<Core::NodeId> servers;
+            NameServers servers;
             DNS(servers);
 
             std::list<string> dnsList;
@@ -987,10 +998,19 @@ POP_WARNING()
         END_INTERFACE_MAP
 
     private:
-        DHCPEngine& AddInterface(const string& interfaceName, const Entry& entry)
+        DHCPEngine& AddInterface(Core::AdapterIterator& hardware, const Entry& entry)
         {
-            std::map<const string, const Entry>::const_iterator more(_info.find(interfaceName));
+            string interfaceName(hardware.Name());
+            NetworkConfigs::const_iterator more(_info.find(interfaceName));
             const Entry& info = (more != _info.end()? more->second : entry);
+
+            if ( (entry.MAC.IsSet() == true) && ((!entry.MAC.IsNull()) || (info.MAC.IsSet() && (!info.MAC.IsNull()))) ) {
+                uint8_t buffer[DHCPClient::MACSize];
+                Core::FromHexString(entry.MAC.IsNull() ? info.MAC.Value() : entry.MAC.Value(), buffer, sizeof(buffer), ':');
+                if (hardware.MACAddress(buffer) != Core::ERROR_NONE) {
+                    SYSLOG(Logging::Startup, (_T("Interface [%s], could not set requested MAC address"), interfaceName.c_str()));
+                }
+            }
 
             auto element = _dhcpInterfaces.emplace(std::piecewise_construct,
                 std::forward_as_tuple(interfaceName),
@@ -1001,10 +1021,9 @@ POP_WARNING()
 
         uint32_t Reload(const string& interfaceName, const bool dynamic)
         {
-
             uint32_t result = Core::ERROR_UNKNOWN_KEY;
 
-            std::map<const string, DHCPEngine>::iterator index(_dhcpInterfaces.find(interfaceName));
+            Networks::iterator index(_dhcpInterfaces.find(interfaceName));
 
             if (index != _dhcpInterfaces.end()) {
 
@@ -1014,6 +1033,10 @@ POP_WARNING()
                     SYSLOG(Logging::Notification, (_T("Adapter [%s] not available or in the wrong state."), interfaceName.c_str()));
                 }
                 else {
+                    uint8_t mac[6];
+                    adapter.MACAddress(mac, sizeof(mac));
+                    index->second.UpdateMAC(mac, sizeof(mac));
+
                     if (index->second.Info().Address().IsValid() == true) {
                         result = SetIP(adapter, index->second.Info().Address(), index->second.Info().Gateway(), index->second.Info().Broadcast(), true);
                     }
@@ -1021,9 +1044,6 @@ POP_WARNING()
                         SYSLOG(Logging::Notification, (_T("Invalid Static IP address: %s, for interface: %s"), index->second.Info().Address().HostAddress().c_str(), interfaceName.c_str()));
                     }
                     if (dynamic == true) {
-                        uint8_t mac[6];
-                        adapter.MACAddress(mac, sizeof(mac));
-                        index->second.UpdateMAC(mac, sizeof(mac));
                         index->second.Discover(index->second.Info().Address());
                         result = Core::ERROR_NONE;
                     }
@@ -1129,7 +1149,7 @@ POP_WARNING()
             Loads list of previously saved offers and adds it to unleased list
             for requesting in future.
         */
-        bool Load(const string& filename, std::map<const string, const Entry>& info)
+        bool Load(const string& filename, NetworkConfigs& info)
         {
             bool result = false;
 
@@ -1203,7 +1223,7 @@ POP_WARNING()
 
             while (adapter.Next() == true) {
                 const string name (adapter.Name());
-                std::map<const string, DHCPEngine>::iterator index (_dhcpInterfaces.find(name));
+                Networks::iterator index (_dhcpInterfaces.find(name));
 
                 if (index != _dhcpInterfaces.end()) {
                     bool hasValidIP = ExternallyAccessible(adapter);
@@ -1235,7 +1255,7 @@ POP_WARNING()
 
         void Accepted(const string& interfaceName, const DHCPClient::Offer& offer)
         {
-            std::map<const string, DHCPEngine>::iterator entry(_dhcpInterfaces.find(interfaceName));
+            Networks::iterator entry(_dhcpInterfaces.find(interfaceName));
 
             if (entry != _dhcpInterfaces.end()) {
 
@@ -1269,7 +1289,7 @@ POP_WARNING()
         {
             _adminLock.Lock();
 
-            std::map<const string, DHCPEngine>::iterator index(_dhcpInterfaces.find(interfaceName));
+            Networks::iterator index(_dhcpInterfaces.find(interfaceName));
 
             if (index != _dhcpInterfaces.end()) {
 
@@ -1339,11 +1359,11 @@ POP_WARNING()
 
                 offset = (static_cast<uint16_t>(file.Size()) - reduction);
 
-                std::list<Core::NodeId> servers;
+                NameServers servers;
                 DNS(servers);
 
                 for (const Core::NodeId& entry : servers) {
-                    data += string(NameServer) + entry.HostAddress() + '\n';
+                    data += string("nameserver ") + entry.HostAddress() + '\n';
                 }
 
                 data += endMarker;
@@ -1361,7 +1381,7 @@ POP_WARNING()
 
             if (adapter.IsValid() == true) {
 
-                std::map<const string, DHCPEngine>::iterator index(_dhcpInterfaces.find(interfaceName));
+                Networks::iterator index(_dhcpInterfaces.find(interfaceName));
 
                 // Send a message with the state of the adapter.
                 string message = string(_T("{ \"interface\": \"")) + interfaceName + string(_T("\", \"running\": \"")) + string(adapter.IsRunning() ? _T("true") : _T("false")) + string(_T("\", \"up\": \"")) + string(adapter.IsUp() ? _T("true") : _T("false")) + _T("\", \"event\": \"");
@@ -1404,7 +1424,7 @@ POP_WARNING()
                                 Core::AdapterIterator hardware(interfaceName);
 
                                 if (hardware.IsValid() == true) {
-                                    DHCPEngine& engine = AddInterface(interfaceName, listIndex.Current());
+                                    DHCPEngine& engine = AddInterface(hardware, listIndex.Current());
 
                                     if (hardware.IsUp() == false) {
                                         hardware.Up(true);
@@ -1437,7 +1457,7 @@ POP_WARNING()
             }
         }
 
-        uint32_t NetworkInfo(const std::map<const string, DHCPEngine>::const_iterator& engine, std::list<Exchange::INetworkControl::NetworkInfo>& networksInfo) const
+        uint32_t NetworkInfo(const Networks::const_iterator& engine, std::list<Exchange::INetworkControl::NetworkInfo>& networksInfo) const
         {
             Exchange::INetworkControl::NetworkInfo networkInfo;
             networkInfo.address = engine->second.Info().Address().HostAddress();
@@ -1453,7 +1473,7 @@ POP_WARNING()
         {
             uint32_t result = Core::ERROR_NONE;
 
-            std::map<const string, DHCPEngine>::const_iterator engine(_dhcpInterfaces.find(interface));
+            Networks::const_iterator engine(_dhcpInterfaces.find(interface));
             _adminLock.Lock();
             if (engine != _dhcpInterfaces.end()) {
                 _adminLock.Unlock();
@@ -1484,7 +1504,7 @@ POP_WARNING()
             return result;
         }
  
-        void DNS(std::list<Core::NodeId>& servers) const
+        void DNS(NameServers& servers) const
         {
             _adminLock.Lock();
 
@@ -1519,18 +1539,18 @@ POP_WARNING()
     private:
         mutable Core::CriticalSection _adminLock;
         Config _config;
-        std::map<const string, const Entry> _info;
+        NetworkConfigs _info;
         string _dnsFile;
         string _persistentStoragePath;
         uint8_t _responseTime;
         uint8_t _retries;
-        std::list<Core::NodeId> _dns;
-        std::list<string> _requiredSet;
-        std::map<const string, DHCPEngine> _dhcpInterfaces;
+        NameServers _dns;
+        RequiredSets _requiredSet;
+        Networks _dhcpInterfaces;
         AdapterObserver _observer;
         bool _open;
         PluginHost::IShell* _service;
-        std::vector<Exchange::INetworkControl::INotification*> _notifications;
+        Notifications _notifications;
     };
 
     SERVICE_REGISTRATION(NetworkControlImplementation, 1, 0)


### PR DESCRIPTION
The BPI (Banana Pi BPI-M2 ZERO), has a wired and Wifi stack. The MAC address assigned to these
NIC's is however, by default randomly generated and thus changes on each boot.
The MAC could be fixed in several ways:
1) Set a MAC in the DTS overlay (how to make sure it is unique ??)
2) Set a MAC through UBOOT (jpw tp make sure it is unique ??)
3) Enhance the NetworkControl plugin :-)

This commit addresses option 3. The NetworkControl plugin can now have a "mac" field per interface. The "mac" field
can hold a mac address like "AA:BB:CC:DD:EE:FF" or it can be set to null.

If it contains a "real" MAC address, it will set that MAC address on the interface before starting it (if it is
not already started). To resolve the unique issue, you can also set null for the mac field, than the NetworkControl
plugin will check if it had run before (there is in the PersistentStorage space a file with the last run information)
and use the MAC address from that time (effectively maintaining the first auto generated MAC address).

**Message for RDK devloppers**: Yes you can also implement this functionality using one of the scripts used today,simple call the _ifconfig_ command to get the MAC address, store it somewhere and later retrieve it from such a file. However that is probably more error prone :-)

Problem Solved !