### PR TITLE
[Actions] Managing dependencies to make the workflows callable from different repos

### DIFF
--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -5,10 +5,13 @@ on:
     # branches: ["master"]
   pull_request:
     branches: ["master"]
-  workflow_call:
 
 jobs:
+  Thunder:
+    uses: VeithMetro/Thunder/.github/workflows/Linux build template.yml@development/actions
+
   ThunderInterfaces:
+    needs: Thunder
     uses: rdkcentral/ThunderInterfaces/.github/workflows/Build ThunderInterfaces on Linux.yml@master
 
   ThunderNanoServices:

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderNanoServices on Linux
 
 on:
   push:
-    # branches: ["master"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -2,7 +2,7 @@ name: Build ThunderNanoServices on Linux
 
 on:
   push:
-    branches: ["master"]
+    # branches: ["master"]
   pull_request:
     branches: ["master"]
   workflow_call:
@@ -13,97 +13,4 @@ jobs:
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        build_type: [Debug, Release, MinSizeRel]
-
-    name: Build type - ${{matrix.build_type}}
-    steps:
-    - name: Install necessary packages
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 10
-        max_attempts: 10
-        command: |
-          sudo gem install apt-spy2
-          sudo apt-spy2 fix --commit --launchpad --country=US
-          sudo apt-get update
-          sudo apt install python3-pip
-          pip install jsonref
-          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
-
-    - name: Checkout Thunder
-      uses: actions/checkout@v3
-      with:
-        path: Thunder
-        repository: ${{github.repository_owner}}/Thunder
-
-    - name: Checkout ThunderInterfaces
-      uses: actions/checkout@v3
-      with:
-        path: ThunderInterfaces
-        repository: ${{github.repository_owner}}/ThunderInterfaces
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: ThunderInterfaces-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}
-
-    - name: Unpack files
-      run: |
-        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
-
-    - name: Checkout ThunderNanoServices
-      uses: actions/checkout@v3
-      with:
-        path: ThunderNanoServices
-        repository: ${{github.repository_owner}}/ThunderNanoServices
-
-    - name: Regex ThunderNanoServices
-      if: contains(github.event.pull_request.body, '[Options:')
-      id: plugins
-      uses: AsasInnab/regex-action@v1
-      with:
-        regex_pattern: '(?<=\[Options:).*(?=\])'
-        regex_flags: 'gim'
-        search_string: ${{github.event.pull_request.body}}
-
-    - name: Build ThunderNanoServices
-      run: |
-        cmake -G Ninja -S ThunderNanoServices -B ${{matrix.build_type}}/build/ThunderNanoServices \
-        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
-        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
-        -DPLUGIN_CECCONTROL=ON \
-        -DPLUGIN_COMMANDER=ON \
-        -DPLUGIN_DHCPSERVER=ON \
-        -DPLUGIN_DIALSERVER=ON \
-        -DPLUGIN_DICTIONARY=ON \
-        -DPLUGIN_FILETRANSFER=ON \
-        -DPLUGIN_IOCONNECTOR=ON \
-        -DPLUGIN_INPUTSWITCH=ON \
-        -DPLUGIN_NETWORKCONTROL=ON \
-        -DPLUGIN_PROCESSMONITOR=ON \
-        -DPLUGIN_RESOURCEMONITOR=ON \
-        -DPLUGIN_SYSTEMCOMMANDS=ON \
-        -DPLUGIN_SWITCHBOARD=ON \
-        -DPLUGIN_WEBPROXY=ON \
-        -DPLUGIN_WEBSERVER=ON \
-        -DPLUGIN_WEBSHELL=ON \
-        -DPLUGIN_WIFICONTROL=ON \
-        ${{steps.plugins.outputs.first_match}}
-        cmake --build ${{matrix.build_type}}/build/ThunderNanoServices --target install
-
-    - name: Tar files
-      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
-
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: ThunderNanoServices-${{matrix.build_type}}-artifact
-        path: ${{matrix.build_type}}.tar.gz
+    uses: VeithMetro/ThunderNanoServices/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -12,7 +12,7 @@ jobs:
 
   ThunderInterfaces:
     needs: Thunder
-    uses: rdkcentral/ThunderInterfaces/.github/workflows/Build ThunderInterfaces on Linux.yml@master
+    uses: VeithMetro/ThunderInterfaces/.github/workflows/Linux build template.yml@development/actions
 
   ThunderNanoServices:
     needs: ThunderInterfaces

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -13,4 +13,4 @@ jobs:
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-    uses: VeithMetro/ThunderNanoServices/.github/workflows/Linux build template.yml@master
+    uses: VeithMetro/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -1,0 +1,101 @@
+name: Linux build template
+
+on:
+  workflow_call:
+
+jobs:
+  ThunderNanoServices:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build_type: [Debug, Release, MinSizeRel]
+
+    name: Build type - ${{matrix.build_type}}
+    steps:
+    - name: Install necessary packages
+      uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 10
+        max_attempts: 10
+        command: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+          sudo apt-get update
+          sudo apt install python3-pip
+          pip install jsonref
+          sudo apt install build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev libssl-dev
+
+    - name: Checkout Thunder
+      uses: actions/checkout@v3
+      with:
+        path: Thunder
+        repository: ${{github.repository_owner}}/Thunder
+
+    - name: Checkout ThunderInterfaces
+      uses: actions/checkout@v3
+      with:
+        path: ThunderInterfaces
+        repository: ${{github.repository_owner}}/ThunderInterfaces
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: ThunderInterfaces-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}
+
+    - name: Unpack files
+      run: |
+        tar -xvzf ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+        rm ${{matrix.build_type}}/${{matrix.build_type}}.tar.gz
+
+    - name: Checkout ThunderNanoServices
+      uses: actions/checkout@v3
+      with:
+        path: ThunderNanoServices
+        repository: ${{github.repository_owner}}/ThunderNanoServices
+
+    - name: Regex ThunderNanoServices
+      if: contains(github.event.pull_request.body, '[Options:')
+      id: plugins
+      uses: AsasInnab/regex-action@v1
+      with:
+        regex_pattern: '(?<=\[Options:).*(?=\])'
+        regex_flags: 'gim'
+        search_string: ${{github.event.pull_request.body}}
+
+    - name: Build ThunderNanoServices
+      run: |
+        cmake -G Ninja -S ThunderNanoServices -B ${{matrix.build_type}}/build/ThunderNanoServices \
+        -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
+        -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
+        -DPLUGIN_CECCONTROL=ON \
+        -DPLUGIN_COMMANDER=ON \
+        -DPLUGIN_DHCPSERVER=ON \
+        -DPLUGIN_DIALSERVER=ON \
+        -DPLUGIN_DICTIONARY=ON \
+        -DPLUGIN_FILETRANSFER=ON \
+        -DPLUGIN_IOCONNECTOR=ON \
+        -DPLUGIN_INPUTSWITCH=ON \
+        -DPLUGIN_NETWORKCONTROL=ON \
+        -DPLUGIN_PROCESSMONITOR=ON \
+        -DPLUGIN_RESOURCEMONITOR=ON \
+        -DPLUGIN_SYSTEMCOMMANDS=ON \
+        -DPLUGIN_SWITCHBOARD=ON \
+        -DPLUGIN_WEBPROXY=ON \
+        -DPLUGIN_WEBSERVER=ON \
+        -DPLUGIN_WEBSHELL=ON \
+        -DPLUGIN_WIFICONTROL=ON \
+        ${{steps.plugins.outputs.first_match}}
+        cmake --build ${{matrix.build_type}}/build/ThunderNanoServices --target install
+
+    - name: Tar files
+      run: tar -czvf ${{matrix.build_type}}.tar.gz ${{matrix.build_type}}
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: ThunderNanoServices-${{matrix.build_type}}-artifact
+        path: ${{matrix.build_type}}.tar.gz


### PR DESCRIPTION
Same as with the Thunder PR: https://github.com/rdkcentral/Thunder/pull/1496

This is an initial pull request - the new workflows have to be called from my branches for now (there is a dependency between the workflows), since we need to first merge new templates in each repo. Then, I'll make one more set of pull requests to redirect this new feature to master branches of our repos.

Required checks got updated to the new ones by Stephen.