### PR TITLE
Compositor: don't set the PLATFORM subsystem

### DIFF
--- a/Compositor/lib/RPI/RPI.cpp
+++ b/Compositor/lib/RPI/RPI.cpp
@@ -369,7 +369,6 @@ namespace Plugin {
             PluginHost::ISubSystem* subSystems(service->SubSystems());
             ASSERT(subSystems != nullptr);
             if (subSystems != nullptr) {
-                subSystems->Set(PluginHost::ISubSystem::PLATFORM, nullptr);
                 subSystems->Set(PluginHost::ISubSystem::GRAPHICS, nullptr);
                 subSystems->Release();
             }

--- a/Compositor/lib/Wayland/Wayland.cpp
+++ b/Compositor/lib/Wayland/Wayland.cpp
@@ -508,10 +508,6 @@ namespace Plugin {
 
             ASSERT(subSystems != nullptr);
 
-            if (subSystems != nullptr) {
-                subSystems->Set(PluginHost::ISubSystem::PLATFORM, nullptr);
-            }
-
             // As there are currently two flavors of the potential Wayland Compositor Implementations, e.g.
             // Westeros and Weston, we do not want to decide here which one we instantiate. We have given both
             // implemntations a "generic" handle that starts the compositor. Here we just instantiate the


### PR DESCRIPTION
Some implementations were setting the Platform subsystem without providing a actual platform server. 