### PR TITLE
NetworkControl: cmake relax interface dhcp configuration

### DIFF
--- a/NetworkControl/NetworkControl.conf.in
+++ b/NetworkControl/NetworkControl.conf.in
@@ -11,18 +11,24 @@ interface_list = []
 if "@PLUGIN_NETWORKCONTROL_INTERFACES@":
     for interface in "@PLUGIN_NETWORKCONTROL_INTERFACES@".split('|'):
         interface_attr = interface.split(';')
-        if len(interface_attr) == 6:
+
+        if len(interface_attr) >= 1:
             interface_config = JSON()
             interface_config.add("interface", interface_attr[0])
-            interface_config.add("mode", interface_attr[1])
-            if interface_attr[5]:
+            interface_config.add("mode", interface_attr[1] if (len(interface_attr) >= 2) else "Dynamic")
+
+            if (len(interface_attr) >= 6) and interface_attr[5]:
                 interface_config.add("mac", interface_attr[5])
-            if interface_attr[2]:
+            
+            if (len(interface_attr) >= 3) and interface_attr[2]:
                 interface_config.add("address", interface_attr[2])
-            if interface_attr[3]:
+            
+            if (len(interface_attr) >= 4) and interface_attr[3]:
                 interface_config.add("mask", interface_attr[3])
-            if interface_attr[4]:
+            
+            if (len(interface_attr) >= 5) and interface_attr[4]:
                 interface_config.add("gateway", interface_attr[4])
+            
             interface_list.append(interface_config)
 
 configuration.add("interfaces", interface_list)


### PR DESCRIPTION
now you can just configure cmake with ```-DPLUGIN_NETWORKCONTROL_INTERFACES="eth0|wlan0"``` to have DHCP on those interfaces. This is what you want 9/10 times. 
Specific config is still possible by using ```-DPLUGIN_NETWORKCONTROL_INTERFACES="eth0;Static;10.0.0.1;24;10.0.0.254;AA:BB:CC:DD:EE:FF|wlan0;Dynamic;;;;FF:EE:DD:CC:BB:AA"```