### PR TITLE
[Actions] Using the build template from master after the checkout fix

### DIFF
--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions-checkout-branch
+    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@master


### PR DESCRIPTION
The proper branch checkout had to be done in two separate steps so that we didn't need to include the repo admins to bypass the required checks