### PR TITLE
[Actions] Build all of the Bluetooth plugins

### DIFF
--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/actions-extensions
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderInterfaces:
     needs: Thunder
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions-bluetooth
+    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@master

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/actions-extensions
 
   ThunderInterfaces:
     needs: Thunder
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions-bluetooth

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -67,6 +67,10 @@ jobs:
         -DCMAKE_INSTALL_PREFIX="${{matrix.build_type}}/install/usr" \
         -DCMAKE_MODULE_PATH="${PWD}/${{matrix.build_type}}/install/usr/include/WPEFramework/Modules" \
         -DEXAMPLE_COMRPCCLIENT=ON \
+        -DPLUGIN_BLUETOOTH=ON \
+        -DPLUGIN_BLUETOOTHREMOTECONTROL=ON \
+        -DPLUGIN_BLUETOOTHAUDIO=ON \
+        -DPLUGIN_BLUETOOTHSDPSERVER=ON \
         -DPLUGIN_CECCONTROL=ON \
         -DPLUGIN_COMMANDER=ON \
         -DPLUGIN_CONFIGUPDATEEXAMPLE=ON \


### PR DESCRIPTION
Now with the Bluetooth extension with audio and GATT support building in Thunder, we can add all of the Bluetooth plugins to the Linux workflow (a required check)