### PR TITLE
[WebServer] Fixing an invalid iterator

### DIFF
--- a/WebServer/WebServerImplementation.cpp
+++ b/WebServer/WebServerImplementation.cpp
@@ -717,9 +717,10 @@ POP_WARNING()
         {
         }
 
-        ~WebServerImplementation() override {
-            for (auto & observer: _observers){
-                Unregister(observer);
+        ~WebServerImplementation() override
+        {
+            while (!_observers.empty()) {
+                Unregister(_observers.front());
             }
         }
 


### PR DESCRIPTION
The iterator was being invalidated after each [erase](https://github.com/rdkcentral/ThunderNanoServices/blob/master/WebServer/WebServerImplementation.cpp#L810) in `Unregister()`, which caused an undefined behavior like calling the method more times than expected and led to an ASSERT during the framework shutdown