### PR TITLE
[Actions] Patch the Linux workflows after GitHub runners update, disable one warning

### DIFF
--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/disable-warning-array-bounds
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderInterfaces:
     needs: Thunder

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -17,4 +17,4 @@ jobs:
 
   ThunderNanoServices:
     needs: ThunderInterfaces
-    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/ThunderNanoServices/.github/workflows/Linux build template.yml@development/actions-runners-update

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/disable-warning-array-bounds
 
   ThunderInterfaces:
     needs: Thunder

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/bluetooth-uuid
 
   ThunderInterfaces:
     needs: Thunder

--- a/.github/workflows/Build ThunderNanoServices on Linux.yml
+++ b/.github/workflows/Build ThunderNanoServices on Linux.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Thunder:
-    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@development/bluetooth-uuid
+    uses: rdkcentral/Thunder/.github/workflows/Linux build template.yml@master
 
   ThunderInterfaces:
     needs: Thunder

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -50,6 +50,7 @@ jobs:
       with:
         path: ThunderNanoServices
         repository: ${{github.repository_owner}}/ThunderNanoServices
+        ref: development/actions-runners-update
 
     - name: Regex ThunderNanoServices
       if: contains(github.event.pull_request.body, '[Options:')

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ThunderNanoServices:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -28,8 +28,10 @@ jobs:
           echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main universe restricted multiverse" | sudo tee -a /etc/apt/sources.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev zlib1g-dev zlib1g-dev:i386 libssl-dev gcc-11-multilib g++-11-multilib
-          sudo pip install jsonref
+          sudo apt install python3-pip build-essential cmake ninja-build libusb-1.0-0-dev ${{matrix.architecture == '32' && 'zlib1g-dev:i386 libssl-dev:i386 gcc-13-multilib g++-13-multilib' || 'zlib1g-dev libssl-dev'}}
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install jsonref
 
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -61,6 +63,7 @@ jobs:
 # ----- Building & uploading -----
     - name: Build ThunderNanoServices
       run: |
+        source venv/bin/activate
         cmake -G Ninja -S ThunderNanoServices -B ${{matrix.build_type}}/build/ThunderNanoServices \
         -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \
         -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic -Werror -m${{matrix.architecture}}" \

--- a/.github/workflows/Linux build template.yml
+++ b/.github/workflows/Linux build template.yml
@@ -50,7 +50,6 @@ jobs:
       with:
         path: ThunderNanoServices
         repository: ${{github.repository_owner}}/ThunderNanoServices
-        ref: development/actions-runners-update
 
     - name: Regex ThunderNanoServices
       if: contains(github.event.pull_request.body, '[Options:')

--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -1604,8 +1604,9 @@ class BluetoothControl : public PluginHost::IPlugin
             }
             bool IsServiceSupported(const string& serviceUUID) const override
             {
+PUSH_WARNING(DISABLE_WARNING_MAYBE_UNINITIALIZED)
                 Bluetooth::UUID uuid(serviceUUID);
-
+POP_WARNING()
                 _state.Lock();
 
                 const bool result =  (uuid.IsValid() == true? (std::find(_uuids.cbegin(), _uuids.cend(), uuid) != _uuids.cend()) : false);

--- a/BluetoothControl/BluetoothControl.h
+++ b/BluetoothControl/BluetoothControl.h
@@ -1604,9 +1604,8 @@ class BluetoothControl : public PluginHost::IPlugin
             }
             bool IsServiceSupported(const string& serviceUUID) const override
             {
-PUSH_WARNING(DISABLE_WARNING_MAYBE_UNINITIALIZED)
                 Bluetooth::UUID uuid(serviceUUID);
-POP_WARNING()
+
                 _state.Lock();
 
                 const bool result =  (uuid.IsValid() == true? (std::find(_uuids.cbegin(), _uuids.cend(), uuid) != _uuids.cend()) : false);

--- a/DHCPServer/DHCPServerImplementation.h
+++ b/DHCPServer/DHCPServerImplementation.h
@@ -167,9 +167,9 @@ namespace Plugin {
 
                 if (_length > maxLength) {
                     _id._allocation = new uint8_t[_length];
-                    ::copy(id, id + _length, _id._allocation);
+                    std::copy(id, id + _length, _id._allocation);
                 } else {
-                    ::copy(id, id + _length, _id._buffer);
+                    std::copy(id, id + _length, _id._buffer);
                 }
             }
             Identifier(const Identifier& copy)
@@ -177,9 +177,9 @@ namespace Plugin {
             {
                 if (_length > maxLength) {
                     _id._allocation = new uint8_t[_length];
-                    ::copy(copy._id._allocation, copy._id._allocation + _length, _id._allocation);
+                    std::copy(copy._id._allocation, copy._id._allocation + _length, _id._allocation);
                 } else {
-                    ::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
+                    std::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
                 }
             }
             Identifier(const Identifier&& copy)
@@ -189,7 +189,7 @@ namespace Plugin {
                 if (_length > maxLength) {
                     _id._allocation = copy._id._allocation;
                 } else {
-                    ::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
+                    std::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
                 }
             }
             ~Identifier()

--- a/DHCPServer/DHCPServerImplementation.h
+++ b/DHCPServer/DHCPServerImplementation.h
@@ -167,9 +167,9 @@ namespace Plugin {
 
                 if (_length > maxLength) {
                     _id._allocation = new uint8_t[_length];
-                    ::memcpy(_id._allocation, id, _length);
+                    ::copy(id, id + _length, _id._allocation);
                 } else {
-                    ::memcpy(_id._buffer, id, _length);
+                    ::copy(id, id + _length, _id._buffer);
                 }
             }
             Identifier(const Identifier& copy)
@@ -177,9 +177,9 @@ namespace Plugin {
             {
                 if (_length > maxLength) {
                     _id._allocation = new uint8_t[_length];
-                    ::memcpy(_id._allocation, copy._id._allocation, _length);
+                    ::copy(copy._id._allocation, copy._id._allocation + _length, _id._allocation);
                 } else {
-                    ::memcpy(_id._buffer, copy._id._buffer, _length);
+                    ::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
                 }
             }
             Identifier(const Identifier&& copy)
@@ -189,7 +189,7 @@ namespace Plugin {
                 if (_length > maxLength) {
                     _id._allocation = copy._id._allocation;
                 } else {
-                    ::memcpy(_id._buffer, copy._id._buffer, _length);
+                    ::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
                 }
             }
             ~Identifier()

--- a/DHCPServer/DHCPServerImplementation.h
+++ b/DHCPServer/DHCPServerImplementation.h
@@ -161,6 +161,7 @@ namespace Plugin {
             {
                 _id._allocation = nullptr;
             }
+PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
             Identifier(const uint8_t id[], const uint8_t length)
                 : _length(length)
             {
@@ -169,11 +170,10 @@ namespace Plugin {
                     _id._allocation = new uint8_t[_length];
                     ::memcpy(_id._allocation, id, _length);
                 } else {
-PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, id, _length);
-POP_WARNING()
                 }
             }
+POP_WARNING()
             Identifier(const Identifier& copy)
                 : _length(copy._length)
             {
@@ -181,9 +181,7 @@ POP_WARNING()
                     _id._allocation = new uint8_t[_length];
                     ::memcpy(_id._allocation, copy._id._allocation, _length);
                 } else {
-PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, copy._id._buffer, _length);
-POP_WARNING()
                 }
             }
             Identifier(const Identifier&& copy)
@@ -193,9 +191,7 @@ POP_WARNING()
                 if (_length > maxLength) {
                     _id._allocation = copy._id._allocation;
                 } else {
-PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, copy._id._buffer, _length);
-POP_WARNING()
                 }
             }
             ~Identifier()
@@ -220,9 +216,7 @@ POP_WARNING()
                         // Buffer is nolonger needed.
                         delete[] _id._allocation;
                         _length = rhs._length;
-PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                         ::memcpy(_id._buffer, rhs._id._buffer, _length);
-POP_WARNING()
                     }
                 } else if (rhs._length > maxLength) {
                     _length = rhs._length;
@@ -230,9 +224,7 @@ POP_WARNING()
                     ::memcpy(_id._allocation, rhs._id._allocation, _length);
                 } else {
                     _length = rhs._length;
-PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, rhs._id._buffer, _length);
-POP_WARNING()
                 }
 
                 return (*this);

--- a/DHCPServer/DHCPServerImplementation.h
+++ b/DHCPServer/DHCPServerImplementation.h
@@ -169,7 +169,9 @@ namespace Plugin {
                     _id._allocation = new uint8_t[_length];
                     ::memcpy(_id._allocation, id, _length);
                 } else {
+PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, id, _length);
+POP_WARNING()
                 }
             }
             Identifier(const Identifier& copy)
@@ -179,7 +181,9 @@ namespace Plugin {
                     _id._allocation = new uint8_t[_length];
                     ::memcpy(_id._allocation, copy._id._allocation, _length);
                 } else {
+PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, copy._id._buffer, _length);
+POP_WARNING()
                 }
             }
             Identifier(const Identifier&& copy)
@@ -189,7 +193,9 @@ namespace Plugin {
                 if (_length > maxLength) {
                     _id._allocation = copy._id._allocation;
                 } else {
+PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, copy._id._buffer, _length);
+POP_WARNING()
                 }
             }
             ~Identifier()
@@ -214,7 +220,9 @@ namespace Plugin {
                         // Buffer is nolonger needed.
                         delete[] _id._allocation;
                         _length = rhs._length;
+PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                         ::memcpy(_id._buffer, rhs._id._buffer, _length);
+POP_WARNING()
                     }
                 } else if (rhs._length > maxLength) {
                     _length = rhs._length;
@@ -222,7 +230,9 @@ namespace Plugin {
                     ::memcpy(_id._allocation, rhs._id._allocation, _length);
                 } else {
                     _length = rhs._length;
+PUSH_WARNING(DISABLE_WARNING_ARRAY_BOUNDS)
                     ::memcpy(_id._buffer, rhs._id._buffer, _length);
+POP_WARNING()
                 }
 
                 return (*this);

--- a/DHCPServer/DHCPServerImplementation.h
+++ b/DHCPServer/DHCPServerImplementation.h
@@ -167,9 +167,9 @@ namespace Plugin {
 
                 if (_length > maxLength) {
                     _id._allocation = new uint8_t[_length];
-                    std::copy(id, id + _length, _id._allocation);
+                    ::memcpy(_id._allocation, id, _length);
                 } else {
-                    std::copy(id, id + _length, _id._buffer);
+                    ::memcpy(_id._buffer, id, _length);
                 }
             }
             Identifier(const Identifier& copy)
@@ -177,9 +177,9 @@ namespace Plugin {
             {
                 if (_length > maxLength) {
                     _id._allocation = new uint8_t[_length];
-                    std::copy(copy._id._allocation, copy._id._allocation + _length, _id._allocation);
+                    ::memcpy(_id._allocation, copy._id._allocation, _length);
                 } else {
-                    std::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
+                    ::memcpy(_id._buffer, copy._id._buffer, _length);
                 }
             }
             Identifier(const Identifier&& copy)
@@ -189,7 +189,7 @@ namespace Plugin {
                 if (_length > maxLength) {
                     _id._allocation = copy._id._allocation;
                 } else {
-                    std::copy(copy._id._buffer, copy._id._buffer + _length, _id._buffer);
+                    ::memcpy(_id._buffer, copy._id._buffer, _length);
                 }
             }
             ~Identifier()


### PR DESCRIPTION
It looks like compiler got this one warning wrong, and for some reason only in Release and not in Debug. In this case, `memcpy` cannot write to the `uint8_t _buffer[maxLength]` more than the `_buffer` can handle, as it will only write to the buffer if `_length <= maxLength`, so I think it is safe to disable this warning (it has to be on the whole constructor otherwise the warning is still there)

```
FAILED: DHCPServer/CMakeFiles/ThunderDHCPServer.dir/DHCPServer.cpp.o 
/usr/bin/c++ -DBLUEZ_HAS_NO_INCLUSIVE_LANGUAGE -DNO_INCLUSIVE_LANGUAGE -DPROCESSCONTAINERS_ENABLED=1 -DTHUNDER_PLATFORM_PC_UNIX=1 -DThunderDHCPServer_EXPORTS -DWARNING_REPORTING_ENABLED -D_TRACE_LEVEL=0 -D__CORE_BLUETOOTH_SUPPORT__ -D__CORE_MESSAGING__ -D__CORE_NO_WCHAR_SUPPORT__ -D__CORE_WARNING_REPORTING__ -isystem /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder -isystem /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include -isystem /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder/processcontainers -Wall -Wextra -Wpedantic -Werror -m64 -O3 -DNDEBUG -std=gnu++11 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT DHCPServer/CMakeFiles/ThunderDHCPServer.dir/DHCPServer.cpp.o -MF DHCPServer/CMakeFiles/ThunderDHCPServer.dir/DHCPServer.cpp.o.d -o DHCPServer/CMakeFiles/ThunderDHCPServer.dir/DHCPServer.cpp.o -c /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.cpp
In file included from /usr/include/string.h:548,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder/core/Portability.h:408,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder/core/Module.h:26,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder/core/core.h:27,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder/plugins/Module.h:26,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/Release/install/usr/include/Thunder/plugins/plugins.h:30,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/Module.h:26,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServerImplementation.h:23,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.h:22,
                 from /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.cpp:20:
In function ‘void* memcpy(void*, const void*, size_t)’,
    inlined from ‘Thunder::Plugin::DHCPServerImplementation::Identifier::Identifier(const uint8_t*, uint8_t)’ at /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServerImplementation.h:170:29,
    inlined from ‘Thunder::Plugin::DHCPServerImplementation::Identifier::Identifier(const uint8_t*, uint8_t)’ at /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServerImplementation.h:164:13,
    inlined from ‘Thunder::Plugin::DHCPServerImplementation::Lease Thunder::Plugin::DHCPServer::Data::Server::Lease::Get() const’ at /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.h:89:97,
    inlined from ‘void Thunder::Plugin::DHCPServer::LoadLeases(const string&, Thunder::Plugin::DHCPServerImplementation&)’ at /home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.cpp:242:63:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:33: error: ‘void* __builtin___memcpy_chk(void*, const void*, long unsigned int, long unsigned int)’ forming offset 16 is out of the bounds [0, 16] of object ‘buffer’ with type ‘uint8_t [16]’ {aka ‘unsigned char [16]’} [-Werror=array-bounds=]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.h: In member function ‘void Thunder::Plugin::DHCPServer::LoadLeases(const string&, Thunder::Plugin::DHCPServerImplementation&)’:
/home/runner/work/ThunderNanoServices/ThunderNanoServices/ThunderNanoServices/DHCPServer/DHCPServer.h:84:33: note: ‘buffer’ declared here
   84 |                         uint8_t buffer[DHCPServerImplementation::Identifier::maxLength];
      |                                 ^~~~~~
cc1plus: all warnings being treated as errors
```