### PR TITLE
[Actions] Make sure all MacOS job names are unique

### DIFF
--- a/.github/workflows/Build ThunderNanoServices on MacOS.yml
+++ b/.github/workflows/Build ThunderNanoServices on MacOS.yml
@@ -8,13 +8,13 @@ on:
     branches: ["master"]
 
 jobs:
-  Thunder:
+  Thunder_MacOS:
     uses: rdkcentral/Thunder/.github/workflows/MacOS build template.yml@master
 
-  ThunderInterfaces:
-    needs: Thunder
+  ThunderInterfaces_MacOS:
+    needs: Thunder_MacOS
     uses: rdkcentral/ThunderInterfaces/.github/workflows/MacOS build template.yml@master
 
-  ThunderNanoServices:
-    needs: ThunderInterfaces
+  ThunderNanoServices_MacOS:
+    needs: ThunderInterfaces_MacOS
     uses: rdkcentral/ThunderNanoServices/.github/workflows/MacOS build template.yml@master


### PR DESCRIPTION
Otherwise it clashes with the Linux required checks, even despite the workflow name being different