### PR TITLE
[Compositor] Framebuffer unbinding should occur before committing output

### DIFF
--- a/Compositor/lib/Mesa/Compositor.cpp
+++ b/Compositor/lib/Mesa/Compositor.cpp
@@ -882,9 +882,9 @@ namespace Plugin {
 
             _renderer->End(false);
 
-            _output->Commit(); // Blit to screen
-
             _renderer->Unbind(frameBuffer);
+
+            _output->Commit(); // Blit to screen
 
             return Core::Time::Now().Ticks();
         }

--- a/Compositor/lib/Mesa/renderer/test/testclear.cpp
+++ b/Compositor/lib/Mesa/renderer/test/testclear.cpp
@@ -209,10 +209,9 @@ private:
         _renderer->Begin(_connector->Width(), _connector->Height());
         _renderer->Clear(_color);
         _renderer->End();
+        _renderer->Unbind(frameBuffer);
 
         _connector->Commit();
-
-        _renderer->Unbind(frameBuffer);
 
         _rotation += 360. / (_rotationPeriod.count() * (std::chrono::microseconds(std::chrono::seconds(1)).count() / _period.count()));
 

--- a/Compositor/lib/Mesa/renderer/test/testdmabuf.cpp
+++ b/Compositor/lib/Mesa/renderer/test/testdmabuf.cpp
@@ -215,6 +215,8 @@ private:
 
         _renderer->End(false);
 
+        _renderer->Unbind(frameBuffer);
+
         uint32_t commit;
 
         if ((commit = _connector->Commit()) == Core::ERROR_NONE) {
@@ -223,8 +225,6 @@ private:
             TRACE(Trace::Error, ("Commit failed: %d", commit));
             std::this_thread::sleep_for(std::chrono::milliseconds(10)); // just throttle the render thread a bit.
         }
-
-        _renderer->Unbind(frameBuffer);
 
         rotation += _radPerFrame;
     }

--- a/Compositor/lib/Mesa/renderer/test/testquads.cpp
+++ b/Compositor/lib/Mesa/renderer/test/testquads.cpp
@@ -207,11 +207,11 @@ private:
 
         _renderer->End();
 
+        _renderer->Unbind(frameBuffer);
+
         _connector->Commit();
 
         WaitForVSync(100);
-
-        _renderer->Unbind(frameBuffer);
 
         rotation += _period.count() * (2. * M_PI) / float(_rotations * std::chrono::microseconds(std::chrono::seconds(1)).count());
 

--- a/Compositor/lib/Mesa/renderer/test/testtexture.cpp
+++ b/Compositor/lib/Mesa/renderer/test/testtexture.cpp
@@ -211,11 +211,11 @@ private:
 
         _renderer->End(false);
 
+        _renderer->Unbind(frameBuffer);
+
         _connector->Commit();
 
         WaitForVSync(100);
-
-        _renderer->Unbind(frameBuffer);
 
         rotation += _period.count() * (2. * M_PI) / (_rotations * std::chrono::microseconds(std::chrono::seconds(1)).count());
 


### PR DESCRIPTION
This fixes some weird glitching with WebGL