### PR TITLE
[PerformanceMonitor] Make sure THUNDER_PERFORMANCE flag is set

### DIFF
--- a/PerformanceMonitor/CMakeLists.txt
+++ b/PerformanceMonitor/CMakeLists.txt
@@ -44,6 +44,8 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+target_compile_definitions(${MODULE_NAME} PRIVATE "THUNDER_PERFORMANCE=1")
+
 target_link_libraries(${MODULE_NAME}
     PRIVATE
         CompileSettingsDebug::CompileSettingsDebug


### PR DESCRIPTION
First, let's merge [this](https://github.com/rdkcentral/Thunder/pull/1883) PR, which fixes compilation issues in the code behind this flag