### PR TITLE
add DISABLE_WARNING_OVERLOADED_VIRTUALS

### DIFF
--- a/Compositor/lib/Mesa/backend/src/DRM/Connector.h
+++ b/Compositor/lib/Mesa/backend/src/DRM/Connector.h
@@ -91,6 +91,8 @@ namespace Compositor {
                         }
                     }
                 }
+
+                PUSH_WARNING(DISABLE_WARNING_OVERLOADED_VIRTUALS)
                 IIterator* Acquire(const uint32_t timeoutMs)
                 {
                     _swap.Lock();
@@ -101,6 +103,8 @@ namespace Compositor {
                     _swap.Unlock();
                     _buffer[_activePlane ^ 1]->Relinquish();
                 }
+                POP_WARNING()
+
                 uint32_t Width() const
                 {
                     return (_buffer[0]->Width());
@@ -207,6 +211,7 @@ namespace Compositor {
              * Returning the info of the back buffer because its used to
              * draw a new frame.
              */
+            PUSH_WARNING(DISABLE_WARNING_OVERLOADED_VIRTUALS)
             IIterator* Acquire(const uint32_t timeoutMs) override
             {
                 return (_frameBuffer.Acquire(timeoutMs));
@@ -215,6 +220,7 @@ namespace Compositor {
             {
                 _frameBuffer.Relinquish();
             }
+            POP_WARNING()
             uint32_t Width() const override
             {
                 return (_frameBuffer.Width());

--- a/Compositor/lib/Mesa/backend/src/Wayland/Output.cpp
+++ b/Compositor/lib/Mesa/backend/src/Wayland/Output.cpp
@@ -228,6 +228,7 @@ namespace Compositor {
             }       
         }
 
+        PUSH_WARNING(DISABLE_WARNING_OVERLOADED_VIRTUALS)
         Exchange::IGraphicsBuffer::IIterator* WaylandOutput::Acquire(const uint32_t timeoutMs)
         {
             return (_buffer.IsValid() == true) ? _buffer->Acquire(timeoutMs) : nullptr;
@@ -239,6 +240,7 @@ namespace Compositor {
                 _buffer->Relinquish();
             }
         }
+        POP_WARNING()
 
         uint32_t WaylandOutput::Width() const
         {

--- a/Compositor/lib/Mesa/renderer/src/GL/GLES2.cpp
+++ b/Compositor/lib/Mesa/renderer/src/GL/GLES2.cpp
@@ -930,7 +930,7 @@ namespace Compositor {
 
                 _egl.ResetCurrent();
 
-                return  (eglGetError() == EGL_SUCCESS ) ? Core::ERROR_NONE : Core::ERROR_GENERAL;
+                return (eglGetError() == EGL_SUCCESS) ? Core::ERROR_NONE : Core::ERROR_GENERAL;
             }
 
             uint32_t Bind(const Core::ProxyType<IFrameBuffer>& frameBuffer) override
@@ -938,7 +938,7 @@ namespace Compositor {
                 ASSERT(_rendering == false);
 
                 _egl.SetCurrent();
-                
+
                 if (frameBuffer.IsValid() == true) {
                     frameBuffer->Bind();
                 } else {
@@ -1000,6 +1000,7 @@ namespace Compositor {
                 _rendering = false;
             }
 
+            PUSH_WARNING(DISABLE_WARNING_OVERLOADED_VIRTUALS)
             void Clear(const Color color) override
             {
                 ASSERT((_rendering == true) && (_egl.IsCurrent() == true));
@@ -1009,6 +1010,7 @@ namespace Compositor {
                 glClear(GL_COLOR_BUFFER_BIT);
                 PopDebug();
             }
+            POP_WARNING()
 
             void Scissor(const Exchange::IComposition::Rectangle* box) override
             {


### PR DESCRIPTION
Hiding GCC 14.2 warnings that become errors, checked it with @MFransen69 and this was the best for now.