### PR TITLE
[SecureShellServer] Fix all compilations errors and warnings

### DIFF
--- a/SecureShellServer/SecureShellServer.h
+++ b/SecureShellServer/SecureShellServer.h
@@ -45,7 +45,7 @@ namespace Plugin {
             ~Data() override = default;
 
         public:
-            Core::JSON::ArrayType<JsonData::SecureShellServer::SessioninfoResultData> SessionInfo;
+            Core::JSON::ArrayType<JsonData::SecureShellServer::GetactivesessionsinfoResultDataElem> SessionInfo;
             Core::JSON::DecUInt32 ActiveCount;
         };
 
@@ -103,7 +103,7 @@ namespace Plugin {
                 }
 
             public:
-                uint32_t Count() override
+                uint32_t Count() const override
                 {
                    return (static_cast<uint32_t>(_list.size()));
                 }
@@ -219,7 +219,7 @@ namespace Plugin {
 
         // SecureShellServer methods
         uint32_t GetSessionsCount(ISecureShellServer::IClient::IIterator* iter);
-        uint32_t GetSessionsInfo(Core::JSON::ArrayType<JsonData::SecureShellServer::SessioninfoResultData>& sessioninfo);
+        uint32_t GetSessionsInfo(Core::JSON::ArrayType<JsonData::SecureShellServer::GetactivesessionsinfoResultDataElem>& sessioninfo);
         uint32_t CloseClientSession(ISecureShellServer::IClient* client);
 
     private:
@@ -232,8 +232,8 @@ namespace Plugin {
         void UnregisterAll();
         
         uint32_t endpoint_getactivesessionscount(Core::JSON::DecUInt32& response);
-        uint32_t endpoint_getactivesessionsinfo(Core::JSON::ArrayType<JsonData::SecureShellServer::SessioninfoResultData>& response);
-        uint32_t endpoint_closeclientsession(const JsonData::SecureShellServer::SessioninfoResultData& params);
+        uint32_t endpoint_getactivesessionsinfo(Core::JSON::ArrayType<JsonData::SecureShellServer::GetactivesessionsinfoResultDataElem>& response);
+        uint32_t endpoint_closeclientsession(const JsonData::SecureShellServer::GetactivesessionsinfoResultDataElem& params);
 
         uint8_t _skipURL;
         std::string _InputParameters;

--- a/SecureShellServer/SecureShellServerJsonRpc.cpp
+++ b/SecureShellServer/SecureShellServerJsonRpc.cpp
@@ -32,8 +32,8 @@ namespace Plugin {
     void SecureShellServer::RegisterAll()
     {
 	Register<void, Core::JSON::DecUInt32>(_T("getactivesessionscount"), &SecureShellServer::endpoint_getactivesessionscount, this);
-	Register<void, Core::JSON::ArrayType<SessioninfoResultData>>(_T("getactivesessionsinfo"), &SecureShellServer::endpoint_getactivesessionsinfo, this);
-	Register<SessioninfoResultData,void>(_T("closeclientsession"), &SecureShellServer::endpoint_closeclientsession, this);
+	Register<void, Core::JSON::ArrayType<GetactivesessionsinfoResultDataElem>>(_T("getactivesessionsinfo"), &SecureShellServer::endpoint_getactivesessionsinfo, this);
+	Register<GetactivesessionsinfoResultDataElem,void>(_T("closeclientsession"), &SecureShellServer::endpoint_closeclientsession, this);
     }
 
     void SecureShellServer::UnregisterAll()
@@ -72,7 +72,7 @@ namespace Plugin {
     //  - ERROR_NONE: Success
     //  - ERROR_INCORRECT_URL: Incorrect URL given
     // Get details of each active SSH client sessions managed by Dropbear Service.
-    uint32_t SecureShellServer::endpoint_getactivesessionsinfo(Core::JSON::ArrayType<SessioninfoResultData>& response)
+    uint32_t SecureShellServer::endpoint_getactivesessionsinfo(Core::JSON::ArrayType<GetactivesessionsinfoResultDataElem>& response)
     {
         uint32_t result = Core::ERROR_NONE;
 
@@ -86,11 +86,11 @@ namespace Plugin {
     //  - ERROR_NONE: Success
     //  - ERROR_INCORRECT_URL: Incorrect URL given
     // Close a SSH client session.
-    uint32_t SecureShellServer::endpoint_closeclientsession(const JsonData::SecureShellServer::SessioninfoResultData& params)
+    uint32_t SecureShellServer::endpoint_closeclientsession(const JsonData::SecureShellServer::GetactivesessionsinfoResultDataElem& params)
     {
         uint32_t result = Core::ERROR_NONE;
 	ClientImpl* client =
-		Core::ServiceType<SecureShellServer::ClientImpl>::Create<ClientImpl>(params.IpAddress.Value(), params.TimeStamp.Value(), params.Pid.Value());
+		Core::ServiceType<SecureShellServer::ClientImpl>::Create<ClientImpl>(params.Ipaddress.Value(), params.Timestamp.Value(), std::to_string(params.Pid.Value()));
 
         if(params.Pid.IsSet() == true) {
             TRACE(Trace::Information, (_T("closing client session with pid: %s"), params.Pid.Value()));

--- a/SecureShellServer/cmake/FindLibDropbear.cmake
+++ b/SecureShellServer/cmake/FindLibDropbear.cmake
@@ -31,16 +31,32 @@ elseif(LibDropbear_FIND_REQUIRED)
 endif()
 
 find_package(PkgConfig)
-pkg_check_modules(PC_LIBDROPBEAR ${_LIBDROPBEAR_MODE} LibDropbear)
+pkg_check_modules(PC_LIBDROPBEAR ${_LIBDROPBEAR_MODE} libdropbear)
 
 
 if(PC_LIBDROPBEAR_FOUND)
-    set(LIBDROPBEAR_INCLUDE_DIRS ${PC_LIBDROPBEAR_INCLUDEDIR})
+    set(LIBDROPBEAR_INCLUDE_DIRS ${PC_LIBDROPBEAR_INCLUDE_DIRS})
     find_library(LIBDROPBEAR_LIBRARIES
-        NAMES libdropbear.so
+        NAMES libdropbear.a
         HINTS ${PC_LIBDROPBEAR_LIBRARY_DIRS} ${PC_LIBDROPBEAR_LIBDIR}
     )
     set(LIBDROPBEAR_LIBRARY_DIRS ${PC_LIBDROPBEAR_LIBRARY_DIRS})
+
+    find_library(LIBTOMCRYPT_LIBRARY
+        NAMES libtomcrypt.a
+        HINTS ${PC_LIBDROPBEAR_LIBRARY_DIRS} ${PC_LIBDROPBEAR_LIBDIR}
+    )
+    if(LIBTOMCRYPT_LIBRARY)
+        list(APPEND LIBDROPBEAR_LIBRARIES ${LIBTOMCRYPT_LIBRARY})
+    endif()
+
+    find_library(LIBTOMMATH_LIBRARY
+        NAMES libtommath.a
+        HINTS ${PC_LIBDROPBEAR_LIBRARY_DIRS} ${PC_LIBDROPBEAR_LIBDIR}
+    )
+    if(LIBTOMMATH_LIBRARY)
+        list(APPEND LIBDROPBEAR_LIBRARIES ${LIBTOMMATH_LIBRARY})
+    endif()
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
In the end, at the current state the plugin will not work without a proper Dropbear hack - making it build a library that we can link against. So in the future, it would probably be best to drop Dropbear entirely, and move towards a different method of managing the SSH connections