### PR TITLE
Update GLES2.cpp

### DIFF
--- a/Compositor/lib/Mesa/renderer/src/GL/GLES2.cpp
+++ b/Compositor/lib/Mesa/renderer/src/GL/GLES2.cpp
@@ -1359,11 +1359,11 @@ namespace Compositor {
 
     } // namespace Renderer
 
-    Core::ProxyType<IRenderer> IRenderer::Instance(Core::instance_id identifier)
+    Core::ProxyType<IRenderer> IRenderer::Instance(Identifier identifier)
     {
         ASSERT(int(identifier) >= 0); // this should be a valid file descriptor.
 
-        static Core::ProxyMapType<Core::instance_id, IRenderer> glRenderers;
+        static Core::ProxyMapType<Identifier, IRenderer> glRenderers;
 
         return glRenderers.Instance<Renderer::GLES>(identifier, static_cast<int>(identifier));
     }


### PR DESCRIPTION
If you start mixing 64 bits for COMRPC on a 32 bits platform, and the signature on IRendere, is Identifier, you get a compilation issue :-)