### PR TITLE
Development/benchmark qa

### DIFF
--- a/tests/Benchmark/Benchmark.conf.in
+++ b/tests/Benchmark/Benchmark.conf.in
@@ -1,0 +1,8 @@
+startmode = "@PLUGIN_BENCHMARK_STARTMODE@"
+resumed = "@PLUGIN_BENCHMARK_RESUMED@"
+
+configuration = JSON()
+
+root = JSON()
+root.add("mode", "@PLUGIN_BENCHMARK_MODE@")
+configuration.add("root", root)

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -1,0 +1,187 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Benchmark.h"
+#include <qa_interfaces/json/JBenchmark.h>
+
+namespace Thunder {
+namespace BenchmarkMemory {
+    Exchange::IMemory* MemoryObserver(const RPC::IRemoteConnection* connection)
+    {
+        class MemoryObserverImpl : public Exchange::IMemory {
+        public:
+            MemoryObserverImpl() = delete;
+            MemoryObserverImpl(const MemoryObserverImpl&) = delete;
+            MemoryObserverImpl& operator=(const MemoryObserverImpl&) = delete;
+
+            MemoryObserverImpl(const RPC::IRemoteConnection* connection)
+                : _main(connection == nullptr ? Core::ProcessInfo().Id() : connection->RemoteId())
+            {
+            }
+            ~MemoryObserverImpl() = default;
+
+        public:
+            uint64_t Resident() const override
+            {
+                return _main.Resident();
+            }
+            uint64_t Allocated() const override
+            {
+                return _main.Allocated();
+            }
+            uint64_t Shared() const override
+            {
+                return _main.Shared();
+            }
+            uint8_t Processes() const override
+            {
+                return (IsOperational() ? 1 : 0);
+            }
+            bool IsOperational() const override
+            {
+                return _main.IsActive();
+            }
+
+            BEGIN_INTERFACE_MAP(MemoryObserverImpl)
+                INTERFACE_ENTRY(Exchange::IMemory)
+            END_INTERFACE_MAP
+
+        private:
+            Core::ProcessInfo _main;
+        };
+
+        Exchange::IMemory* result = Core::ServiceType<MemoryObserverImpl>::Create<Exchange::IMemory>(connection);
+        return (result);
+    }
+}
+namespace Plugin {
+
+    namespace {
+
+        static Metadata<Benchmark> metadata(
+            // Version
+            1, 0, 0,
+            // Preconditions
+            {},
+            // Terminations
+            {},
+            // Controls
+            {}
+        );
+    }
+
+    const string Benchmark::Initialize(PluginHost::IShell* service)
+    {
+        ASSERT(_benchmark == nullptr);
+        ASSERT(_memory == nullptr);
+        ASSERT(_service == nullptr);
+        ASSERT(service != nullptr);
+        ASSERT(_connectionId == 0);
+
+        _service = service;
+        _service->AddRef();
+
+        _service->Register(&_notification);
+
+        _benchmark = _service->Root<QualityAssurance::IBenchmark>(_connectionId, 2000, _T("BenchmarkImplementation"));
+
+        string result;
+        if (_benchmark == nullptr) {
+            result = _T("Couldn't create Benchmark instance");
+        } else {
+            QualityAssurance::JBenchmark::Register(*this, _benchmark);
+
+            _benchmark->Register(&_benchmarkNotification);
+
+            if (_connectionId == 0) {
+                _memory = Thunder::BenchmarkMemory::MemoryObserver(nullptr);
+            } else {
+                const RPC::IRemoteConnection* connection = _service->RemoteConnection(_connectionId);
+                if (connection == nullptr) {
+                    result = _T("Benchmark crashed at initialize!");
+                } else {
+                    _memory = Thunder::BenchmarkMemory::MemoryObserver(connection);
+                    ASSERT(_memory != nullptr);
+                    connection->Release();
+                }
+            }
+
+            if (_memory == nullptr) {
+                result = _T("Benchmark could not instantiate a Memory observer!");
+            }
+        }
+
+        return (result);
+    }
+
+    void Benchmark::Deinitialize(PluginHost::IShell* service VARIABLE_IS_NOT_USED)
+    {
+        ASSERT(_service == service);
+
+        _service->Unregister(&_notification);
+
+        if (_memory != nullptr) {
+            _memory->Release();
+            _memory = nullptr;
+        }
+
+        if (_benchmark != nullptr) {
+            _benchmark->Unregister(&_benchmarkNotification);
+
+            QualityAssurance::JBenchmark::Unregister(*this);
+
+            RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
+
+            VARIABLE_IS_NOT_USED uint32_t result = _benchmark->Release();
+
+            ASSERT((result == Core::ERROR_CONNECTION_CLOSED) || (result == Core::ERROR_DESTRUCTION_SUCCEEDED));
+
+            if (connection != nullptr) {
+                connection->Terminate();
+                connection->Release();
+            }
+
+            _benchmark = nullptr;
+        }
+
+        _service->Release();
+        _service = nullptr;
+        _connectionId = 0;
+    }
+
+    string Benchmark::Information() const
+    {
+        return string();
+    }
+
+    void Benchmark::Deactivated(RPC::IRemoteConnection* connection)
+    {
+        if (_connectionId == connection->Id()) {
+            ASSERT(_service != nullptr);
+            Core::IWorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
+        }
+    }
+
+    void Benchmark::BenchmarkCompleted()
+    {
+        QualityAssurance::JBenchmark::Event::PerformanceCheckCompleted(*this);
+    }
+
+}
+}

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -20,6 +20,7 @@
 #include "Benchmark.h"
 #include <qa_interfaces/json/JBenchmark.h>
 
+#include <algorithm>
 #include <cinttypes>
 #include <cmath>
 #include <cstdio>

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -441,12 +441,15 @@ namespace Plugin {
             // First run with thresholds: store as baseline
             for (auto& r : _results) {
                 _baselines[r.apiName] = r;
-                r.passed = true;
+                // Preserve passed=false from COM-RPC call failures
             }
         } else if (hasThresholds) {
             // Subsequent runs: compare against baseline
             for (auto& r : _results) {
-                r.passed = true;
+                if (r.passed == false) {
+                    // COM-RPC call failed during measurement; don't override
+                    continue;
+                }
                 r.failureReason.Clear();
                 bool latencyFailed = false;
                 bool memoryFailed = false;
@@ -483,9 +486,11 @@ namespace Plugin {
                 }
             }
         } else {
-            // No thresholds: everything passes
+            // No thresholds: mark as passed only if COM-RPC calls succeeded
             for (auto& r : _results) {
-                r.passed = true;
+                if (r.passed != false) {
+                    r.passed = true;
+                }
             }
         }
         _adminLock.Unlock();

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -415,15 +415,15 @@ namespace Plugin {
             return _payloadProxy->SendReceiveSampleData(in, out);
         }));
 
-        addResult(MeasurePayloadMethod("SendUint32Array", iterations, _memory, [this]() -> uint32_t {
+        addResult(MeasurePayloadMethod("SendUint32Vector", iterations, _memory, [this]() -> uint32_t {
             const std::vector<uint32_t> data = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            return _payloadProxy->SendUint32Array(data);
+            return _payloadProxy->SendUint32Vector(data);
         }));
 
-        addResult(MeasurePayloadMethod("SendReceiveUint32Array", iterations, _memory, [this]() -> uint32_t {
+        addResult(MeasurePayloadMethod("SendReceiveUint32Vector", iterations, _memory, [this]() -> uint32_t {
             const std::vector<uint32_t> input = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             std::vector<uint32_t> output;
-            return _payloadProxy->SendReceiveUint32Array(input, output);
+            return _payloadProxy->SendReceiveUint32Vector(input, output);
         }));
 
         addResult(MeasurePayloadMethod("Add", iterations, _memory, [this]() -> uint32_t {

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -290,8 +290,8 @@ namespace Plugin {
         PluginHost::JSONRPC::RegisterVersion(_T("JBenchmark"), 1, 0, 0);
 
         // Method: 'trigger' — runs benchmarks via COM-RPC proxy
-        PluginHost::JSONRPC::Register<JsonData::Benchmark::TriggerParamsData, Core::JSON::Boolean>(_T("trigger"),
-            [this](const JsonData::Benchmark::TriggerParamsData& params, Core::JSON::Boolean& success) -> uint32_t {
+        PluginHost::JSONRPC::Register<JsonData::Benchmark::TriggerParamsData, void>(_T("trigger"),
+            [this](const JsonData::Benchmark::TriggerParamsData& params) -> uint32_t {
                 if ((params.IsSet() == false) || (params.IsDataValid() == false)) {
                     return Core::ERROR_BAD_REQUEST;
                 }
@@ -310,10 +310,9 @@ namespace Plugin {
                     [](const QualityAssurance::IBenchmark::BenchmarkResult& r) { return r.passed; });
                 _adminLock.Unlock();
 
-                success = allPassed;
                 TRACE(Trace::Information, (_T("Benchmark completed: %u iterations via COM-RPC proxy"),
                     static_cast<uint32_t>(params.Iterations)));
-                return Core::ERROR_NONE;
+                return allPassed ? Core::ERROR_NONE : Core::ERROR_GENERAL;
             });
 
         // Method: 'collectdata' — returns shell-side results
@@ -329,8 +328,8 @@ namespace Plugin {
             });
 
         // Method: 'setthreshold' — stores thresholds on the shell side
-        PluginHost::JSONRPC::Register<JsonData::Benchmark::SetThresholdParamsData, Core::JSON::Boolean>(_T("setthreshold"),
-            [this](const JsonData::Benchmark::SetThresholdParamsData& params, Core::JSON::Boolean& success) -> uint32_t {
+        PluginHost::JSONRPC::Register<JsonData::Benchmark::SetThresholdParamsData, void>(_T("setthreshold"),
+            [this](const JsonData::Benchmark::SetThresholdParamsData& params) -> uint32_t {
                 if ((params.IsSet() == false) || (params.IsDataValid() == false)) {
                     return Core::ERROR_BAD_REQUEST;
                 }
@@ -341,9 +340,8 @@ namespace Plugin {
                 _baselines.clear();
                 _adminLock.Unlock();
 
-                success = true;
-                TRACE(Trace::Information, (_T("Thresholds set: latency=%.1f%%, memory=%" PRIu64 " bytes"),
-                    static_cast<float>(params.MaxLatencyDeviationPct),
+                TRACE(Trace::Information, (_T("Thresholds set: latency=%u millipercent, memory=%" PRIu64 " bytes"),
+                    static_cast<uint32_t>(params.MaxLatencyDeviationPct),
                     static_cast<uint64_t>(params.MaxMemoryGrowthBytes)));
                 return Core::ERROR_NONE;
             });
@@ -374,20 +372,28 @@ namespace Plugin {
             _payloadProxy->SendUint64(UINT64_C(123456789));
         }));
 
+        addResult(MeasurePayloadMethod("GetPayloadTypes", iterations, [this]() {
+            QualityAssurance::IBenchmarkPayload::IPayloadTypeIterator* iter = nullptr;
+            _payloadProxy->GetPayloadTypes(iter);
+            if (iter != nullptr) {
+                iter->Release();
+            }
+        }));
+
         addResult(MeasurePayloadMethod("SendString", iterations, [this]() {
             _payloadProxy->SendString(_T("benchmark_payload_string"));
         }));
 
         addResult(MeasurePayloadMethod("SendSampleData", iterations, [this]() {
-            QualityAssurance::SampleData data;
+            QualityAssurance::IBenchmarkPayload::SampleData data;
             data.id = 1;
             data.value = 100;
             data.name = _T("sample");
             _payloadProxy->SendSampleData(data);
         }));
 
-        addResult(MeasurePayloadMethod("SendWithNoParameters", iterations, [this]() {
-            _payloadProxy->SendWithNoParameters();
+        addResult(MeasurePayloadMethod("SendNoPayload", iterations, [this]() {
+            _payloadProxy->SendNoPayload();
         }));
 
         addResult(MeasurePayloadMethod("SendReceiveUint32", iterations, [this]() {
@@ -401,11 +407,11 @@ namespace Plugin {
         }));
 
         addResult(MeasurePayloadMethod("SendReceiveSampleData", iterations, [this]() {
-            QualityAssurance::SampleData in;
+            QualityAssurance::IBenchmarkPayload::SampleData in;
             in.id = 1;
             in.value = 200;
             in.name = _T("roundtrip");
-            QualityAssurance::SampleData out;
+            QualityAssurance::IBenchmarkPayload::SampleData out;
             _payloadProxy->SendReceiveSampleData(in, out);
         }));
 
@@ -418,7 +424,7 @@ namespace Plugin {
     void Benchmark::ApplyThresholds()
     {
         _adminLock.Lock();
-        bool hasThresholds = (_maxLatencyDeviationPct > 0.0f || _maxMemoryGrowthBytes > 0);
+        bool hasThresholds = (_maxLatencyDeviationPct > 0 || _maxMemoryGrowthBytes > 0);
 
         if (hasThresholds && _baselines.empty()) {
             // First run with thresholds: store as baseline
@@ -434,16 +440,16 @@ namespace Plugin {
 
                 auto baseline = _baselines.find(r.apiName);
                 if (baseline != _baselines.end()) {
-                    // Latency check
-                    if (_maxLatencyDeviationPct > 0.0f && baseline->second.roundTrip.avgNs > 0) {
+                    // Latency check (threshold is in millipercent: 1000 = 1%)
+                    if (_maxLatencyDeviationPct > 0 && baseline->second.roundTrip.avgNs > 0) {
                         double baselineAvg = static_cast<double>(baseline->second.roundTrip.avgNs);
                         double currentAvg = static_cast<double>(r.roundTrip.avgNs);
-                        double deviationPct = ((currentAvg - baselineAvg) / baselineAvg) * 100.0;
-                        if (deviationPct > static_cast<double>(_maxLatencyDeviationPct)) {
+                        double deviationMillipct = ((currentAvg - baselineAvg) / baselineAvg) * 100000.0;
+                        if (deviationMillipct > static_cast<double>(_maxLatencyDeviationPct)) {
                             r.passed = false;
                             char buf[256];
-                            snprintf(buf, sizeof(buf), "latency deviation %.1f%% exceeds %.1f%% threshold (baseline=%" PRIu64 " ns, current=%" PRIu64 " ns)",
-                                deviationPct, static_cast<double>(_maxLatencyDeviationPct),
+                            snprintf(buf, sizeof(buf), "latency deviation %.0f millipercent exceeds %u millipercent threshold (baseline=%" PRIu64 " ns, current=%" PRIu64 " ns)",
+                                deviationMillipct, _maxLatencyDeviationPct,
                                 baseline->second.roundTrip.avgNs, r.roundTrip.avgNs);
                             r.failureReason = string(buf);
                         }

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -287,10 +287,10 @@ namespace Plugin {
 
     void Benchmark::RegisterJsonRpcHandlers()
     {
-        PluginHost::JSONRPC::RegisterVersion(_T("JBenchmark"), 1, 0, 0);
+        PluginHost::JSONRPC::RegisterVersion(_T("JBenchmark"), 2, 0, 0);
 
-        // Method: 'trigger' — runs benchmarks via COM-RPC proxy
-        PluginHost::JSONRPC::Register<JsonData::Benchmark::TriggerParamsData, void>(_T("trigger"),
+        // Method: 'Trigger' — runs benchmarks via COM-RPC proxy
+        PluginHost::JSONRPC::Register<JsonData::Benchmark::TriggerParamsData, void>(_T("Trigger"),
             [this](const JsonData::Benchmark::TriggerParamsData& params) -> uint32_t {
                 if ((params.IsSet() == false) || (params.IsDataValid() == false)) {
                     return Core::ERROR_BAD_REQUEST;
@@ -315,8 +315,8 @@ namespace Plugin {
                 return allPassed ? Core::ERROR_NONE : Core::ERROR_GENERAL;
             });
 
-        // Method: 'collectdata' — returns shell-side results
-        PluginHost::JSONRPC::Register<void, Core::JSON::ArrayType<JsonData::Benchmark::BenchmarkResultData>>(_T("collectdata"),
+        // Method: 'CollectData' — returns shell-side results
+        PluginHost::JSONRPC::Register<void, Core::JSON::ArrayType<JsonData::Benchmark::BenchmarkResultData>>(_T("CollectData"),
             [this](Core::JSON::ArrayType<JsonData::Benchmark::BenchmarkResultData>& report) -> uint32_t {
                 _adminLock.Lock();
                 report.Set(true);
@@ -327,31 +327,21 @@ namespace Plugin {
                 return Core::ERROR_NONE;
             });
 
-        // Method: 'setthreshold' — stores thresholds on the shell side
-        PluginHost::JSONRPC::Register<JsonData::Benchmark::SetThresholdParamsData, void>(_T("setthreshold"),
-            [this](const JsonData::Benchmark::SetThresholdParamsData& params) -> uint32_t {
-                if ((params.IsSet() == false) || (params.IsDataValid() == false)) {
-                    return Core::ERROR_BAD_REQUEST;
-                }
+        // Property: 'LatencyThreshold' — max allowed latency deviation in millipercent
+        PluginHost::JSONRPC::Property<Core::JSON::DecUInt32>(_T("LatencyThreshold"),
+            &Benchmark::GetLatencyThreshold, &Benchmark::SetLatencyThreshold, this);
 
-                _adminLock.Lock();
-                _maxLatencyDeviationPct = params.MaxLatencyDeviationPct;
-                _maxMemoryGrowthBytes = params.MaxMemoryGrowthBytes;
-                _baselines.clear();
-                _adminLock.Unlock();
-
-                TRACE(Trace::Information, (_T("Thresholds set: latency=%u millipercent, memory=%" PRIu64 " bytes"),
-                    static_cast<uint32_t>(params.MaxLatencyDeviationPct),
-                    static_cast<uint64_t>(params.MaxMemoryGrowthBytes)));
-                return Core::ERROR_NONE;
-            });
+        // Property: 'MemoryThreshold' — max allowed RSS growth in bytes
+        PluginHost::JSONRPC::Property<Core::JSON::DecUInt64>(_T("MemoryThreshold"),
+            &Benchmark::GetMemoryThreshold, &Benchmark::SetMemoryThreshold, this);
     }
 
     void Benchmark::UnregisterJsonRpcHandlers()
     {
-        PluginHost::JSONRPC::Unregister(_T("trigger"));
-        PluginHost::JSONRPC::Unregister(_T("collectdata"));
-        PluginHost::JSONRPC::Unregister(_T("setthreshold"));
+        PluginHost::JSONRPC::Unregister(_T("Trigger"));
+        PluginHost::JSONRPC::Unregister(_T("CollectData"));
+        PluginHost::JSONRPC::Unregister(_T("LatencyThreshold"));
+        PluginHost::JSONRPC::Unregister(_T("MemoryThreshold"));
     }
 
     void Benchmark::RunPayloadBenchmarks(uint32_t iterations)
@@ -415,6 +405,17 @@ namespace Plugin {
             _payloadProxy->SendReceiveSampleData(in, out);
         }));
 
+        addResult(MeasurePayloadMethod("SendUint32Array", iterations, [this]() {
+            const std::vector<uint32_t> data = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            _payloadProxy->SendUint32Array(data);
+        }));
+
+        addResult(MeasurePayloadMethod("SendReceiveUint32Array", iterations, [this]() {
+            const std::vector<uint32_t> input = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            std::vector<uint32_t> output;
+            _payloadProxy->SendReceiveUint32Array(input, output);
+        }));
+
         addResult(MeasurePayloadMethod("Add", iterations, [this]() {
             uint32_t result = 0;
             _payloadProxy->Add(17, 25, result);
@@ -436,7 +437,9 @@ namespace Plugin {
             // Subsequent runs: compare against baseline
             for (auto& r : _results) {
                 r.passed = true;
-                r.failureReason = string();
+                r.failureReason.Clear();
+                bool latencyFailed = false;
+                bool memoryFailed = false;
 
                 auto baseline = _baselines.find(r.apiName);
                 if (baseline != _baselines.end()) {
@@ -446,28 +449,26 @@ namespace Plugin {
                         double currentAvg = static_cast<double>(r.roundTrip.avgNs);
                         double deviationMillipct = ((currentAvg - baselineAvg) / baselineAvg) * 100000.0;
                         if (deviationMillipct > static_cast<double>(_maxLatencyDeviationPct)) {
-                            r.passed = false;
-                            char buf[256];
-                            snprintf(buf, sizeof(buf), "latency deviation %.0f millipercent exceeds %u millipercent threshold (baseline=%" PRIu64 " ns, current=%" PRIu64 " ns)",
-                                deviationMillipct, _maxLatencyDeviationPct,
-                                baseline->second.roundTrip.avgNs, r.roundTrip.avgNs);
-                            r.failureReason = string(buf);
+                            latencyFailed = true;
                         }
                     }
                     // Memory check
                     if (_maxMemoryGrowthBytes > 0) {
                         int64_t growth = static_cast<int64_t>(r.memory.residentAfter) - static_cast<int64_t>(r.memory.residentBefore);
                         if (growth > 0 && static_cast<uint64_t>(growth) > _maxMemoryGrowthBytes) {
-                            r.passed = false;
-                            char buf[256];
-                            snprintf(buf, sizeof(buf), "memory growth %" PRId64 " bytes exceeds %" PRIu64 " byte threshold",
-                                growth, _maxMemoryGrowthBytes);
-                            string memMsg(buf);
-                            if (!r.failureReason.empty()) {
-                                r.failureReason += "; ";
-                            }
-                            r.failureReason += memMsg;
+                            memoryFailed = true;
                         }
+                    }
+
+                    if (latencyFailed && memoryFailed) {
+                        r.passed = false;
+                        r.failureReason = QualityAssurance::IBenchmark::LATENCY_AND_MEMORY_THRESHOLD_EXCEEDED;
+                    } else if (latencyFailed) {
+                        r.passed = false;
+                        r.failureReason = QualityAssurance::IBenchmark::LATENCY_THRESHOLD_EXCEEDED;
+                    } else if (memoryFailed) {
+                        r.passed = false;
+                        r.failureReason = QualityAssurance::IBenchmark::MEMORY_THRESHOLD_EXCEEDED;
                     }
                 }
             }
@@ -478,6 +479,42 @@ namespace Plugin {
             }
         }
         _adminLock.Unlock();
+    }
+
+    uint32_t Benchmark::GetLatencyThreshold(Core::JSON::DecUInt32& value) const
+    {
+        _adminLock.Lock();
+        value = _maxLatencyDeviationPct;
+        _adminLock.Unlock();
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t Benchmark::SetLatencyThreshold(const Core::JSON::DecUInt32& value)
+    {
+        _adminLock.Lock();
+        _maxLatencyDeviationPct = value;
+        _baselines.clear();
+        _adminLock.Unlock();
+        TRACE(Trace::Information, (_T("Latency threshold set: %u millipercent"), static_cast<uint32_t>(value)));
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t Benchmark::GetMemoryThreshold(Core::JSON::DecUInt64& value) const
+    {
+        _adminLock.Lock();
+        value = _maxMemoryGrowthBytes;
+        _adminLock.Unlock();
+        return Core::ERROR_NONE;
+    }
+
+    uint32_t Benchmark::SetMemoryThreshold(const Core::JSON::DecUInt64& value)
+    {
+        _adminLock.Lock();
+        _maxMemoryGrowthBytes = value;
+        _baselines.clear();
+        _adminLock.Unlock();
+        TRACE(Trace::Information, (_T("Memory threshold set: %" PRIu64 " bytes"), static_cast<uint64_t>(value)));
+        return Core::ERROR_NONE;
     }
 
 }

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -136,40 +136,48 @@ namespace Plugin {
 
         template<typename CALLABLE>
         QualityAssurance::IBenchmark::BenchmarkResult MeasurePayloadMethod(
-            const string& apiName, uint32_t iterations, CALLABLE&& fn)
+            const string& apiName, uint32_t iterations, Exchange::IMemory* memory, CALLABLE&& fn)
         {
-            Core::ProcessInfo processInfo(Core::ProcessInfo().Id());
+            ASSERT(memory != nullptr);
 
-            uint64_t residentBefore = processInfo.Resident();
-            uint64_t allocatedBefore = processInfo.Allocated();
+            uint64_t residentBefore = memory->Resident();
+            uint64_t allocatedBefore = memory->Allocated();
 
             LatencyAccumulator acc;
+            uint32_t completedIterations = 0;
 
             // Single pass: time each call individually, derive avg from the sum
             Core::StopWatch batchTimer;
             for (uint32_t i = 0; i < iterations; i++) {
                 Core::StopWatch timer;
-                fn();
+                uint32_t hr = fn();
                 uint64_t elapsedUs = timer.Elapsed();
+                if (hr != Core::ERROR_NONE) {
+                    SYSLOG(Logging::Error, (_T("COM-RPC call '%s' failed on iteration %u with error 0x%08X"),
+                        apiName.c_str(), i, hr));
+                    break;
+                }
                 acc.Record(elapsedUs);
+                completedIterations++;
             }
             uint64_t totalBatchUs = batchTimer.Elapsed();
 
-            uint64_t residentAfter = processInfo.Resident();
-            uint64_t allocatedAfter = processInfo.Allocated();
+            uint64_t residentAfter = memory->Resident();
+            uint64_t allocatedAfter = memory->Allocated();
 
             QualityAssurance::IBenchmark::BenchmarkResult result{};
             result.apiName = apiName;
-            result.iterations = iterations;
+            result.iterations = completedIterations;
             result.roundTrip = acc.Stats();
             // Override avgNs with batch-derived value for better precision
-            if (iterations > 0) {
-                result.roundTrip.avgNs = (totalBatchUs * 1000) / iterations;
+            if (completedIterations > 0) {
+                result.roundTrip.avgNs = (totalBatchUs * 1000) / completedIterations;
             }
             result.memory.residentBefore = residentBefore;
             result.memory.residentAfter = residentAfter;
             result.memory.allocatedBefore = allocatedBefore;
             result.memory.allocatedAfter = allocatedAfter;
+            result.passed = (completedIterations == iterations);
 
             return result;
         }
@@ -354,71 +362,72 @@ namespace Plugin {
             _adminLock.Unlock();
         };
 
-        addResult(MeasurePayloadMethod("SendUint32", iterations, [this]() {
-            _payloadProxy->SendUint32(42);
+        addResult(MeasurePayloadMethod("SendUint32", iterations, _memory, [this]() -> uint32_t {
+            return _payloadProxy->SendUint32(42);
         }));
 
-        addResult(MeasurePayloadMethod("SendUint64", iterations, [this]() {
-            _payloadProxy->SendUint64(UINT64_C(123456789));
+        addResult(MeasurePayloadMethod("SendUint64", iterations, _memory, [this]() -> uint32_t {
+            return _payloadProxy->SendUint64(UINT64_C(123456789));
         }));
 
-        addResult(MeasurePayloadMethod("GetPayloadTypes", iterations, [this]() {
+        addResult(MeasurePayloadMethod("GetPayloadTypes", iterations, _memory, [this]() -> uint32_t {
             QualityAssurance::IBenchmarkPayload::IPayloadTypeIterator* iter = nullptr;
-            _payloadProxy->GetPayloadTypes(iter);
+            uint32_t hr = _payloadProxy->GetPayloadTypes(iter);
             if (iter != nullptr) {
                 iter->Release();
             }
+            return hr;
         }));
 
-        addResult(MeasurePayloadMethod("SendString", iterations, [this]() {
-            _payloadProxy->SendString(_T("benchmark_payload_string"));
+        addResult(MeasurePayloadMethod("SendString", iterations, _memory, [this]() -> uint32_t {
+            return _payloadProxy->SendString(_T("benchmark_payload_string"));
         }));
 
-        addResult(MeasurePayloadMethod("SendSampleData", iterations, [this]() {
+        addResult(MeasurePayloadMethod("SendSampleData", iterations, _memory, [this]() -> uint32_t {
             QualityAssurance::IBenchmarkPayload::SampleData data;
             data.id = 1;
             data.value = 100;
             data.name = _T("sample");
-            _payloadProxy->SendSampleData(data);
+            return _payloadProxy->SendSampleData(data);
         }));
 
-        addResult(MeasurePayloadMethod("SendNoPayload", iterations, [this]() {
-            _payloadProxy->SendNoPayload();
+        addResult(MeasurePayloadMethod("SendNoPayload", iterations, _memory, [this]() -> uint32_t {
+            return _payloadProxy->SendNoPayload();
         }));
 
-        addResult(MeasurePayloadMethod("SendReceiveUint32", iterations, [this]() {
+        addResult(MeasurePayloadMethod("SendReceiveUint32", iterations, _memory, [this]() -> uint32_t {
             uint32_t out = 0;
-            _payloadProxy->SendReceiveUint32(42, out);
+            return _payloadProxy->SendReceiveUint32(42, out);
         }));
 
-        addResult(MeasurePayloadMethod("SendReceiveString", iterations, [this]() {
+        addResult(MeasurePayloadMethod("SendReceiveString", iterations, _memory, [this]() -> uint32_t {
             string out;
-            _payloadProxy->SendReceiveString(_T("benchmark_roundtrip"), out);
+            return _payloadProxy->SendReceiveString(_T("benchmark_roundtrip"), out);
         }));
 
-        addResult(MeasurePayloadMethod("SendReceiveSampleData", iterations, [this]() {
+        addResult(MeasurePayloadMethod("SendReceiveSampleData", iterations, _memory, [this]() -> uint32_t {
             QualityAssurance::IBenchmarkPayload::SampleData in;
             in.id = 1;
             in.value = 200;
             in.name = _T("roundtrip");
             QualityAssurance::IBenchmarkPayload::SampleData out;
-            _payloadProxy->SendReceiveSampleData(in, out);
+            return _payloadProxy->SendReceiveSampleData(in, out);
         }));
 
-        addResult(MeasurePayloadMethod("SendUint32Array", iterations, [this]() {
+        addResult(MeasurePayloadMethod("SendUint32Array", iterations, _memory, [this]() -> uint32_t {
             const std::vector<uint32_t> data = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            _payloadProxy->SendUint32Array(data);
+            return _payloadProxy->SendUint32Array(data);
         }));
 
-        addResult(MeasurePayloadMethod("SendReceiveUint32Array", iterations, [this]() {
+        addResult(MeasurePayloadMethod("SendReceiveUint32Array", iterations, _memory, [this]() -> uint32_t {
             const std::vector<uint32_t> input = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             std::vector<uint32_t> output;
-            _payloadProxy->SendReceiveUint32Array(input, output);
+            return _payloadProxy->SendReceiveUint32Array(input, output);
         }));
 
-        addResult(MeasurePayloadMethod("Add", iterations, [this]() {
+        addResult(MeasurePayloadMethod("Add", iterations, _memory, [this]() -> uint32_t {
             uint32_t result = 0;
-            _payloadProxy->Add(17, 25, result);
+            return _payloadProxy->Add(17, 25, result);
         }));
     }
 

--- a/tests/Benchmark/Benchmark.cpp
+++ b/tests/Benchmark/Benchmark.cpp
@@ -20,6 +20,10 @@
 #include "Benchmark.h"
 #include <qa_interfaces/json/JBenchmark.h>
 
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+
 namespace Thunder {
 namespace BenchmarkMemory {
     Exchange::IMemory* MemoryObserver(const RPC::IRemoteConnection* connection)
@@ -86,6 +90,92 @@ namespace Plugin {
         );
     }
 
+    namespace {
+
+        struct LatencyAccumulator {
+            std::vector<uint64_t> samplesUs;
+
+            void Record(uint64_t us)
+            {
+                samplesUs.push_back(us);
+            }
+
+            QualityAssurance::IBenchmark::RoundTripStats Stats() const
+            {
+                QualityAssurance::IBenchmark::RoundTripStats stats{};
+                if (samplesUs.empty()) return stats;
+
+                uint64_t sum = 0;
+                uint64_t minVal = UINT64_MAX;
+                uint64_t maxVal = 0;
+
+                for (auto v : samplesUs) {
+                    sum += v;
+                    if (v < minVal) minVal = v;
+                    if (v > maxVal) maxVal = v;
+                }
+
+                uint64_t avg = sum / samplesUs.size();
+
+                double variance = 0.0;
+                for (auto v : samplesUs) {
+                    double diff = static_cast<double>(v) - static_cast<double>(avg);
+                    variance += diff * diff;
+                }
+                variance /= samplesUs.size();
+
+                // Convert µs to ns for the interface
+                stats.minNs = minVal * 1000;
+                stats.avgNs = avg * 1000;
+                stats.maxNs = maxVal * 1000;
+                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance)) * 1000;
+
+                return stats;
+            }
+        };
+
+        template<typename CALLABLE>
+        QualityAssurance::IBenchmark::BenchmarkResult MeasurePayloadMethod(
+            const string& apiName, uint32_t iterations, CALLABLE&& fn)
+        {
+            Core::ProcessInfo processInfo(Core::ProcessInfo().Id());
+
+            uint64_t residentBefore = processInfo.Resident();
+            uint64_t allocatedBefore = processInfo.Allocated();
+
+            LatencyAccumulator acc;
+
+            // Single pass: time each call individually, derive avg from the sum
+            Core::StopWatch batchTimer;
+            for (uint32_t i = 0; i < iterations; i++) {
+                Core::StopWatch timer;
+                fn();
+                uint64_t elapsedUs = timer.Elapsed();
+                acc.Record(elapsedUs);
+            }
+            uint64_t totalBatchUs = batchTimer.Elapsed();
+
+            uint64_t residentAfter = processInfo.Resident();
+            uint64_t allocatedAfter = processInfo.Allocated();
+
+            QualityAssurance::IBenchmark::BenchmarkResult result{};
+            result.apiName = apiName;
+            result.iterations = iterations;
+            result.roundTrip = acc.Stats();
+            // Override avgNs with batch-derived value for better precision
+            if (iterations > 0) {
+                result.roundTrip.avgNs = (totalBatchUs * 1000) / iterations;
+            }
+            result.memory.residentBefore = residentBefore;
+            result.memory.residentAfter = residentAfter;
+            result.memory.allocatedBefore = allocatedBefore;
+            result.memory.allocatedAfter = allocatedAfter;
+
+            return result;
+        }
+
+    } // anonymous namespace
+
     const string Benchmark::Initialize(PluginHost::IShell* service)
     {
         ASSERT(_benchmark == nullptr);
@@ -105,25 +195,32 @@ namespace Plugin {
         if (_benchmark == nullptr) {
             result = _T("Couldn't create Benchmark instance");
         } else {
-            QualityAssurance::JBenchmark::Register(*this, _benchmark);
-
-            _benchmark->Register(&_benchmarkNotification);
-
-            if (_connectionId == 0) {
-                _memory = Thunder::BenchmarkMemory::MemoryObserver(nullptr);
-            } else {
-                const RPC::IRemoteConnection* connection = _service->RemoteConnection(_connectionId);
-                if (connection == nullptr) {
-                    result = _T("Benchmark crashed at initialize!");
-                } else {
-                    _memory = Thunder::BenchmarkMemory::MemoryObserver(connection);
-                    ASSERT(_memory != nullptr);
-                    connection->Release();
-                }
+            _payloadProxy = _benchmark->QueryInterface<QualityAssurance::IBenchmarkPayload>();
+            if (_payloadProxy == nullptr) {
+                result = _T("Couldn't obtain IBenchmarkPayload interface from Benchmark implementation");
             }
 
-            if (_memory == nullptr) {
-                result = _T("Benchmark could not instantiate a Memory observer!");
+            if (result.empty()) {
+                RegisterJsonRpcHandlers();
+
+                _benchmark->Register(&_benchmarkNotification);
+
+                if (_connectionId == 0) {
+                    _memory = Thunder::BenchmarkMemory::MemoryObserver(nullptr);
+                } else {
+                    const RPC::IRemoteConnection* connection = _service->RemoteConnection(_connectionId);
+                    if (connection == nullptr) {
+                        result = _T("Benchmark crashed at initialize!");
+                    } else {
+                        _memory = Thunder::BenchmarkMemory::MemoryObserver(connection);
+                        ASSERT(_memory != nullptr);
+                        connection->Release();
+                    }
+                }
+
+                if (_memory == nullptr && result.empty()) {
+                    result = _T("Benchmark could not instantiate a Memory observer!");
+                }
             }
         }
 
@@ -144,7 +241,12 @@ namespace Plugin {
         if (_benchmark != nullptr) {
             _benchmark->Unregister(&_benchmarkNotification);
 
-            QualityAssurance::JBenchmark::Unregister(*this);
+            UnregisterJsonRpcHandlers();
+
+            if (_payloadProxy != nullptr) {
+                _payloadProxy->Release();
+                _payloadProxy = nullptr;
+            }
 
             RPC::IRemoteConnection* connection(_service->RemoteConnection(_connectionId));
 
@@ -181,6 +283,195 @@ namespace Plugin {
     void Benchmark::BenchmarkCompleted()
     {
         QualityAssurance::JBenchmark::Event::PerformanceCheckCompleted(*this);
+    }
+
+    void Benchmark::RegisterJsonRpcHandlers()
+    {
+        PluginHost::JSONRPC::RegisterVersion(_T("JBenchmark"), 1, 0, 0);
+
+        // Method: 'trigger' — runs benchmarks via COM-RPC proxy
+        PluginHost::JSONRPC::Register<JsonData::Benchmark::TriggerParamsData, Core::JSON::Boolean>(_T("trigger"),
+            [this](const JsonData::Benchmark::TriggerParamsData& params, Core::JSON::Boolean& success) -> uint32_t {
+                if ((params.IsSet() == false) || (params.IsDataValid() == false)) {
+                    return Core::ERROR_BAD_REQUEST;
+                }
+
+                _adminLock.Lock();
+                _results.clear();
+                _adminLock.Unlock();
+
+                RunPayloadBenchmarks(params.Iterations);
+                ApplyThresholds();
+
+                QualityAssurance::JBenchmark::Event::PerformanceCheckCompleted(*this);
+
+                _adminLock.Lock();
+                bool allPassed = std::all_of(_results.begin(), _results.end(),
+                    [](const QualityAssurance::IBenchmark::BenchmarkResult& r) { return r.passed; });
+                _adminLock.Unlock();
+
+                success = allPassed;
+                TRACE(Trace::Information, (_T("Benchmark completed: %u iterations via COM-RPC proxy"),
+                    static_cast<uint32_t>(params.Iterations)));
+                return Core::ERROR_NONE;
+            });
+
+        // Method: 'collectdata' — returns shell-side results
+        PluginHost::JSONRPC::Register<void, Core::JSON::ArrayType<JsonData::Benchmark::BenchmarkResultData>>(_T("collectdata"),
+            [this](Core::JSON::ArrayType<JsonData::Benchmark::BenchmarkResultData>& report) -> uint32_t {
+                _adminLock.Lock();
+                report.Set(true);
+                for (const auto& r : _results) {
+                    report.Add() = r;
+                }
+                _adminLock.Unlock();
+                return Core::ERROR_NONE;
+            });
+
+        // Method: 'setthreshold' — stores thresholds on the shell side
+        PluginHost::JSONRPC::Register<JsonData::Benchmark::SetThresholdParamsData, Core::JSON::Boolean>(_T("setthreshold"),
+            [this](const JsonData::Benchmark::SetThresholdParamsData& params, Core::JSON::Boolean& success) -> uint32_t {
+                if ((params.IsSet() == false) || (params.IsDataValid() == false)) {
+                    return Core::ERROR_BAD_REQUEST;
+                }
+
+                _adminLock.Lock();
+                _maxLatencyDeviationPct = params.MaxLatencyDeviationPct;
+                _maxMemoryGrowthBytes = params.MaxMemoryGrowthBytes;
+                _baselines.clear();
+                _adminLock.Unlock();
+
+                success = true;
+                TRACE(Trace::Information, (_T("Thresholds set: latency=%.1f%%, memory=%" PRIu64 " bytes"),
+                    static_cast<float>(params.MaxLatencyDeviationPct),
+                    static_cast<uint64_t>(params.MaxMemoryGrowthBytes)));
+                return Core::ERROR_NONE;
+            });
+    }
+
+    void Benchmark::UnregisterJsonRpcHandlers()
+    {
+        PluginHost::JSONRPC::Unregister(_T("trigger"));
+        PluginHost::JSONRPC::Unregister(_T("collectdata"));
+        PluginHost::JSONRPC::Unregister(_T("setthreshold"));
+    }
+
+    void Benchmark::RunPayloadBenchmarks(uint32_t iterations)
+    {
+        ASSERT(_payloadProxy != nullptr);
+
+        auto addResult = [this](QualityAssurance::IBenchmark::BenchmarkResult&& r) {
+            _adminLock.Lock();
+            _results.push_back(std::move(r));
+            _adminLock.Unlock();
+        };
+
+        addResult(MeasurePayloadMethod("SendUint32", iterations, [this]() {
+            _payloadProxy->SendUint32(42);
+        }));
+
+        addResult(MeasurePayloadMethod("SendUint64", iterations, [this]() {
+            _payloadProxy->SendUint64(UINT64_C(123456789));
+        }));
+
+        addResult(MeasurePayloadMethod("SendString", iterations, [this]() {
+            _payloadProxy->SendString(_T("benchmark_payload_string"));
+        }));
+
+        addResult(MeasurePayloadMethod("SendSampleData", iterations, [this]() {
+            QualityAssurance::SampleData data;
+            data.id = 1;
+            data.value = 100;
+            data.name = _T("sample");
+            _payloadProxy->SendSampleData(data);
+        }));
+
+        addResult(MeasurePayloadMethod("SendWithNoParameters", iterations, [this]() {
+            _payloadProxy->SendWithNoParameters();
+        }));
+
+        addResult(MeasurePayloadMethod("SendReceiveUint32", iterations, [this]() {
+            uint32_t out = 0;
+            _payloadProxy->SendReceiveUint32(42, out);
+        }));
+
+        addResult(MeasurePayloadMethod("SendReceiveString", iterations, [this]() {
+            string out;
+            _payloadProxy->SendReceiveString(_T("benchmark_roundtrip"), out);
+        }));
+
+        addResult(MeasurePayloadMethod("SendReceiveSampleData", iterations, [this]() {
+            QualityAssurance::SampleData in;
+            in.id = 1;
+            in.value = 200;
+            in.name = _T("roundtrip");
+            QualityAssurance::SampleData out;
+            _payloadProxy->SendReceiveSampleData(in, out);
+        }));
+
+        addResult(MeasurePayloadMethod("Add", iterations, [this]() {
+            uint32_t result = 0;
+            _payloadProxy->Add(17, 25, result);
+        }));
+    }
+
+    void Benchmark::ApplyThresholds()
+    {
+        _adminLock.Lock();
+        bool hasThresholds = (_maxLatencyDeviationPct > 0.0f || _maxMemoryGrowthBytes > 0);
+
+        if (hasThresholds && _baselines.empty()) {
+            // First run with thresholds: store as baseline
+            for (auto& r : _results) {
+                _baselines[r.apiName] = r;
+                r.passed = true;
+            }
+        } else if (hasThresholds) {
+            // Subsequent runs: compare against baseline
+            for (auto& r : _results) {
+                r.passed = true;
+                r.failureReason = string();
+
+                auto baseline = _baselines.find(r.apiName);
+                if (baseline != _baselines.end()) {
+                    // Latency check
+                    if (_maxLatencyDeviationPct > 0.0f && baseline->second.roundTrip.avgNs > 0) {
+                        double baselineAvg = static_cast<double>(baseline->second.roundTrip.avgNs);
+                        double currentAvg = static_cast<double>(r.roundTrip.avgNs);
+                        double deviationPct = ((currentAvg - baselineAvg) / baselineAvg) * 100.0;
+                        if (deviationPct > static_cast<double>(_maxLatencyDeviationPct)) {
+                            r.passed = false;
+                            char buf[256];
+                            snprintf(buf, sizeof(buf), "latency deviation %.1f%% exceeds %.1f%% threshold (baseline=%" PRIu64 " ns, current=%" PRIu64 " ns)",
+                                deviationPct, static_cast<double>(_maxLatencyDeviationPct),
+                                baseline->second.roundTrip.avgNs, r.roundTrip.avgNs);
+                            r.failureReason = string(buf);
+                        }
+                    }
+                    // Memory check
+                    if (_maxMemoryGrowthBytes > 0) {
+                        int64_t growth = static_cast<int64_t>(r.memory.residentAfter) - static_cast<int64_t>(r.memory.residentBefore);
+                        if (growth > 0 && static_cast<uint64_t>(growth) > _maxMemoryGrowthBytes) {
+                            r.passed = false;
+                            char buf[256];
+                            snprintf(buf, sizeof(buf), "memory growth %" PRId64 " bytes exceeds %" PRIu64 " byte threshold",
+                                growth, _maxMemoryGrowthBytes);
+                            string memMsg(buf);
+                            if (!r.failureReason.empty()) {
+                                r.failureReason += "; ";
+                            }
+                            r.failureReason += memMsg;
+                        }
+                    }
+                }
+            }
+        } else {
+            // No thresholds: everything passes
+            for (auto& r : _results) {
+                r.passed = true;
+            }
+        }
+        _adminLock.Unlock();
     }
 
 }

--- a/tests/Benchmark/Benchmark.h
+++ b/tests/Benchmark/Benchmark.h
@@ -1,0 +1,132 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+#include <qa_interfaces/IBenchmark.h>
+#include <interfaces/IMemory.h>
+
+namespace Thunder {
+namespace Plugin {
+
+    class Benchmark : public PluginHost::IPlugin, public PluginHost::JSONRPC {
+    private:
+        class Notification : public RPC::IRemoteConnection::INotification {
+        public:
+            Notification(const Notification&) = delete;
+            Notification& operator=(const Notification&) = delete;
+            Notification(Notification&&) = delete;
+            Notification& operator=(Notification&&) = delete;
+
+            explicit Notification(Benchmark& parent)
+                : _parent(parent)
+            {
+            }
+            ~Notification() override = default;
+
+        public:
+            void Activated(RPC::IRemoteConnection* /* connection */) override
+            {
+            }
+            void Deactivated(RPC::IRemoteConnection* connection) override
+            {
+                _parent.Deactivated(connection);
+            }
+            void Terminated(RPC::IRemoteConnection* /* connection */) override
+            {
+            }
+
+            BEGIN_INTERFACE_MAP(Notification)
+                INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            Benchmark& _parent;
+        };
+
+        class BenchmarkNotification : public QualityAssurance::IBenchmark::INotification {
+        public:
+            BenchmarkNotification(const BenchmarkNotification&) = delete;
+            BenchmarkNotification& operator=(const BenchmarkNotification&) = delete;
+
+            explicit BenchmarkNotification(Benchmark& parent)
+                : _parent(parent)
+            {
+            }
+            ~BenchmarkNotification() override = default;
+
+            void PerformanceCheckCompleted() override
+            {
+                _parent.BenchmarkCompleted();
+            }
+
+            BEGIN_INTERFACE_MAP(BenchmarkNotification)
+                INTERFACE_ENTRY(QualityAssurance::IBenchmark::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            Benchmark& _parent;
+        };
+
+    public:
+        Benchmark(const Benchmark&) = delete;
+        Benchmark& operator=(const Benchmark&) = delete;
+        Benchmark(Benchmark&&) = delete;
+        Benchmark& operator=(Benchmark&&) = delete;
+
+        Benchmark()
+            : _benchmark(nullptr)
+            , _connectionId(0)
+            , _memory(nullptr)
+            , _service(nullptr)
+            , _notification(*this)
+            , _benchmarkNotification(*this)
+        {
+        }
+
+        ~Benchmark() override = default;
+
+        BEGIN_INTERFACE_MAP(Benchmark)
+            INTERFACE_ENTRY(PluginHost::IPlugin)
+            INTERFACE_ENTRY(PluginHost::IDispatcher)
+            INTERFACE_AGGREGATE(QualityAssurance::IBenchmark, _benchmark)
+            INTERFACE_AGGREGATE(Exchange::IMemory, _memory)
+        END_INTERFACE_MAP
+
+        //   IPlugin methods
+        const string Initialize(PluginHost::IShell* service) override;
+        void Deinitialize(PluginHost::IShell* service) override;
+        string Information() const override;
+
+    private:
+        void Deactivated(RPC::IRemoteConnection* connection);
+        void BenchmarkCompleted();
+
+    private:
+        QualityAssurance::IBenchmark* _benchmark;
+        uint32_t _connectionId;
+        Exchange::IMemory* _memory;
+        PluginHost::IShell* _service;
+        Core::SinkType<Notification> _notification;
+        Core::SinkType<BenchmarkNotification> _benchmarkNotification;
+    };
+
+} // namespace Plugin
+} // namespace Thunder

--- a/tests/Benchmark/Benchmark.h
+++ b/tests/Benchmark/Benchmark.h
@@ -129,6 +129,11 @@ namespace Plugin {
         void RunPayloadBenchmarks(uint32_t iterations);
         void ApplyThresholds();
 
+        uint32_t GetLatencyThreshold(Core::JSON::DecUInt32& value) const;
+        uint32_t SetLatencyThreshold(const Core::JSON::DecUInt32& value);
+        uint32_t GetMemoryThreshold(Core::JSON::DecUInt64& value) const;
+        uint32_t SetMemoryThreshold(const Core::JSON::DecUInt64& value);
+
     private:
         QualityAssurance::IBenchmark* _benchmark;
         uint32_t _connectionId;

--- a/tests/Benchmark/Benchmark.h
+++ b/tests/Benchmark/Benchmark.h
@@ -22,7 +22,7 @@
 #include "Module.h"
 #include <qa_interfaces/IBenchmark.h>
 #include <interfaces/IMemory.h>
-#include <qa_interfaces/IBenchmarkPayloadCOMRPC.h>
+#include <qa_interfaces/IBenchmarkPayload.h>
 #include <map>
 #include <vector>
 
@@ -102,7 +102,7 @@ namespace Plugin {
             , _notification(*this)
             , _benchmarkNotification(*this)
             , _payloadProxy(nullptr)
-            , _maxLatencyDeviationPct(0.0f)
+            , _maxLatencyDeviationPct(0)
             , _maxMemoryGrowthBytes(0)
         {
         }
@@ -140,7 +140,7 @@ namespace Plugin {
         mutable Core::CriticalSection _adminLock;
         std::vector<QualityAssurance::IBenchmark::BenchmarkResult> _results;
         std::map<string, QualityAssurance::IBenchmark::BenchmarkResult> _baselines;
-        float _maxLatencyDeviationPct;
+        uint32_t _maxLatencyDeviationPct;
         uint64_t _maxMemoryGrowthBytes;
     };
 

--- a/tests/Benchmark/Benchmark.h
+++ b/tests/Benchmark/Benchmark.h
@@ -22,6 +22,9 @@
 #include "Module.h"
 #include <qa_interfaces/IBenchmark.h>
 #include <interfaces/IMemory.h>
+#include <qa_interfaces/IBenchmarkPayloadCOMRPC.h>
+#include <map>
+#include <vector>
 
 namespace Thunder {
 namespace Plugin {
@@ -98,6 +101,9 @@ namespace Plugin {
             , _service(nullptr)
             , _notification(*this)
             , _benchmarkNotification(*this)
+            , _payloadProxy(nullptr)
+            , _maxLatencyDeviationPct(0.0f)
+            , _maxMemoryGrowthBytes(0)
         {
         }
 
@@ -118,6 +124,10 @@ namespace Plugin {
     private:
         void Deactivated(RPC::IRemoteConnection* connection);
         void BenchmarkCompleted();
+        void RegisterJsonRpcHandlers();
+        void UnregisterJsonRpcHandlers();
+        void RunPayloadBenchmarks(uint32_t iterations);
+        void ApplyThresholds();
 
     private:
         QualityAssurance::IBenchmark* _benchmark;
@@ -126,6 +136,12 @@ namespace Plugin {
         PluginHost::IShell* _service;
         Core::SinkType<Notification> _notification;
         Core::SinkType<BenchmarkNotification> _benchmarkNotification;
+        QualityAssurance::IBenchmarkPayload* _payloadProxy;
+        mutable Core::CriticalSection _adminLock;
+        std::vector<QualityAssurance::IBenchmark::BenchmarkResult> _results;
+        std::map<string, QualityAssurance::IBenchmark::BenchmarkResult> _baselines;
+        float _maxLatencyDeviationPct;
+        uint64_t _maxMemoryGrowthBytes;
     };
 
 } // namespace Plugin

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -315,6 +315,8 @@ namespace Plugin {
         uint32_t SendReceiveBuffer(uint16_t& bufferSize, uint8_t buffer[]) const override
         {
             // Echo — buffer and size remain unchanged
+            (void)bufferSize;
+            (void)buffer;
             return Core::ERROR_NONE;
         }
 

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -1,0 +1,442 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+#include <qa_interfaces/IBenchmark.h>
+#include <qa_interfaces/IBenchmarkPayloadCOMRPC.h>
+
+#include <algorithm>
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <map>
+#include <vector>
+
+namespace Thunder {
+namespace Plugin {
+
+    class BenchmarkImplementation
+        : public QualityAssurance::IBenchmark
+        , public QualityAssurance::IBenchmarkPayload {
+    private:
+        struct LatencyAccumulator {
+            std::vector<uint64_t> samplesUs;
+
+            void Record(uint64_t us)
+            {
+                samplesUs.push_back(us);
+            }
+
+            QualityAssurance::IBenchmark::RoundTripStats Stats() const
+            {
+                QualityAssurance::IBenchmark::RoundTripStats stats{};
+                if (samplesUs.empty()) return stats;
+
+                uint64_t sum = 0;
+                uint64_t minVal = UINT64_MAX;
+                uint64_t maxVal = 0;
+
+                for (auto v : samplesUs) {
+                    sum += v;
+                    if (v < minVal) minVal = v;
+                    if (v > maxVal) maxVal = v;
+                }
+
+                uint64_t avg = sum / samplesUs.size();
+
+                double variance = 0.0;
+                for (auto v : samplesUs) {
+                    double diff = static_cast<double>(v) - static_cast<double>(avg);
+                    variance += diff * diff;
+                }
+                variance /= samplesUs.size();
+
+                // Convert µs to ns for the interface
+                stats.minNs = minVal * 1000;
+                stats.avgNs = avg * 1000;
+                stats.maxNs = maxVal * 1000;
+                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance)) * 1000;
+
+                return stats;
+            }
+        };
+
+    public:
+        BenchmarkImplementation(const BenchmarkImplementation&) = delete;
+        BenchmarkImplementation& operator=(const BenchmarkImplementation&) = delete;
+        BenchmarkImplementation(BenchmarkImplementation&&) = delete;
+        BenchmarkImplementation& operator=(BenchmarkImplementation&&) = delete;
+
+        BenchmarkImplementation()
+            : _adminLock()
+            , _results()
+            , _notifications()
+            , _baselines()
+            , _maxLatencyDeviationPct(0.0f)
+            , _maxMemoryGrowthBytes(0)
+        {
+        }
+
+        ~BenchmarkImplementation() override = default;
+
+        BEGIN_INTERFACE_MAP(BenchmarkImplementation)
+            INTERFACE_ENTRY(QualityAssurance::IBenchmark)
+            INTERFACE_ENTRY(QualityAssurance::IBenchmarkPayload)
+        END_INTERFACE_MAP
+
+        // -------------------------------------------------------------------
+        // IBenchmark
+        // -------------------------------------------------------------------
+
+        Core::hresult Trigger(const uint32_t iterations, bool& success) override
+        {
+            _adminLock.Lock();
+            _results.clear();
+            _adminLock.Unlock();
+
+            RunPayloadBenchmarks(iterations);
+
+            // Apply pass/fail thresholds
+            _adminLock.Lock();
+            bool hasThresholds = (_maxLatencyDeviationPct > 0.0f || _maxMemoryGrowthBytes > 0);
+
+            if (hasThresholds && _baselines.empty()) {
+                // First run with thresholds set: store as baseline, everything passes
+                for (auto& r : _results) {
+                    _baselines[r.apiName] = r;
+                    r.passed = true;
+                }
+            } else if (hasThresholds) {
+                // Subsequent runs: compare against baseline
+                for (auto& r : _results) {
+                    r.passed = true;
+                    r.failureReason = string();
+
+                    auto baseline = _baselines.find(r.apiName);
+                    if (baseline != _baselines.end()) {
+                        // Latency check
+                        if (_maxLatencyDeviationPct > 0.0f && baseline->second.roundTrip.avgNs > 0) {
+                            double baselineAvg = static_cast<double>(baseline->second.roundTrip.avgNs);
+                            double currentAvg = static_cast<double>(r.roundTrip.avgNs);
+                            double deviationPct = ((currentAvg - baselineAvg) / baselineAvg) * 100.0;
+                            if (deviationPct > static_cast<double>(_maxLatencyDeviationPct)) {
+                                r.passed = false;
+                                char buf[256];
+                                snprintf(buf, sizeof(buf), "latency deviation %.1f%% exceeds %.1f%% threshold (baseline=%" PRIu64 " ns, current=%" PRIu64 " ns)",
+                                    deviationPct, static_cast<double>(_maxLatencyDeviationPct),
+                                    baseline->second.roundTrip.avgNs, r.roundTrip.avgNs);
+                                r.failureReason = string(buf);
+                            }
+                        }
+                        // Memory check
+                        if (_maxMemoryGrowthBytes > 0) {
+                            int64_t growth = static_cast<int64_t>(r.memory.residentAfter) - static_cast<int64_t>(r.memory.residentBefore);
+                            if (growth > 0 && static_cast<uint64_t>(growth) > _maxMemoryGrowthBytes) {
+                                r.passed = false;
+                                char buf[256];
+                                snprintf(buf, sizeof(buf), "memory growth %" PRId64 " bytes exceeds %" PRIu64 " byte threshold",
+                                    growth, _maxMemoryGrowthBytes);
+                                string memMsg(buf);
+                                if (!r.failureReason.empty()) {
+                                    r.failureReason += "; ";
+                                }
+                                r.failureReason += memMsg;
+                            }
+                        }
+                    }
+                }
+            } else {
+                // No thresholds: everything passes
+                for (auto& r : _results) {
+                    r.passed = true;
+                }
+            }
+
+            // Notify listeners
+            for (auto* sink : _notifications) {
+                sink->PerformanceCheckCompleted();
+            }
+            _adminLock.Unlock();
+
+            success = true;
+            TRACE(Trace::Information, (_T("Benchmark completed: %u iterations"), iterations));
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult CollectData(IBenchmarkResultIterator*& report) const override
+        {
+            _adminLock.Lock();
+            std::vector<BenchmarkResult> items(_results);
+            _adminLock.Unlock();
+
+            using Iterator = RPC::IteratorType<IBenchmarkResultIterator>;
+            report = Core::ServiceType<Iterator>::Create<IBenchmarkResultIterator>(items);
+
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult Register(const IBenchmark::INotification* sink) override
+        {
+            _adminLock.Lock();
+            auto it = std::find(_notifications.begin(), _notifications.end(), sink);
+            if (it == _notifications.end()) {
+                _notifications.push_back(const_cast<IBenchmark::INotification*>(sink));
+                sink->AddRef();
+            }
+            _adminLock.Unlock();
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult Unregister(const IBenchmark::INotification* sink) override
+        {
+            _adminLock.Lock();
+            auto it = std::find(_notifications.begin(), _notifications.end(), sink);
+            if (it != _notifications.end()) {
+                (*it)->Release();
+                _notifications.erase(it);
+            }
+            _adminLock.Unlock();
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult SetThreshold(const float maxLatencyDeviationPct, const uint64_t maxMemoryGrowthBytes, bool& success) override
+        {
+            _adminLock.Lock();
+            _maxLatencyDeviationPct = maxLatencyDeviationPct;
+            _maxMemoryGrowthBytes = maxMemoryGrowthBytes;
+            // Clear baselines so the next Trigger run becomes the new baseline
+            _baselines.clear();
+            _adminLock.Unlock();
+
+            success = true;
+            TRACE(Trace::Information, (_T("Thresholds set: latency=%.1f%%, memory=%llu bytes"),
+                maxLatencyDeviationPct, maxMemoryGrowthBytes));
+            return Core::ERROR_NONE;
+        }
+
+        // -------------------------------------------------------------------
+        // IBenchmarkPayload — echo/loopback endpoints for COM-RPC measurement
+        // -------------------------------------------------------------------
+
+        uint32_t GetPayloadTypes(IPayloadTypeIterator*& types) const override
+        {
+            std::vector<PayloadType> payloads = {
+                PAYLOAD_SMALL, PAYLOAD_MEDIUM, PAYLOAD_LARGE
+            };
+            using Iterator = RPC::IteratorType<IPayloadTypeIterator>;
+            types = Core::ServiceType<Iterator>::Create<IPayloadTypeIterator>(payloads);
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendUint16(const uint16_t /* value */) override { return Core::ERROR_NONE; }
+        uint32_t SendUint32(const uint32_t /* value */) override { return Core::ERROR_NONE; }
+        uint32_t SendUint64(const uint64_t /* value */) override { return Core::ERROR_NONE; }
+        uint32_t SendBool(const bool /* value */) override { return Core::ERROR_NONE; }
+        uint32_t SendFloat(const float /* value */) override { return Core::ERROR_NONE; }
+        uint32_t SendDouble(const double /* value */) override { return Core::ERROR_NONE; }
+        uint32_t SendString(const string& /* value */) override { return Core::ERROR_NONE; }
+
+        uint32_t SendSampleData(const QualityAssurance::SampleData& /* data */) override
+        {
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendWithNoParameters() override { return Core::ERROR_NONE; }
+
+        uint32_t SendBuffer(const uint16_t /* bufferSize */, const uint8_t[] /* buffer */) override
+        {
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveUint16(const uint16_t input, uint16_t& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveUint32(const uint32_t input, uint32_t& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveUint64(const uint64_t input, uint64_t& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveBool(const bool input, bool& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveFloat(const float input, float& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveDouble(const double input, double& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveString(const string& input, string& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveSampleData(const QualityAssurance::SampleData& input, QualityAssurance::SampleData& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t SendReceiveBuffer(uint16_t& bufferSize, uint8_t buffer[]) const override
+        {
+            // Echo — buffer and size remain unchanged
+            return Core::ERROR_NONE;
+        }
+
+        uint32_t Add(const uint32_t a, const uint32_t b, uint32_t& result) const override
+        {
+            result = a + b;
+            return Core::ERROR_NONE;
+        }
+
+    private:
+        void RunPayloadBenchmarks(uint32_t iterations)
+        {
+            // Benchmark each IBenchmarkPayload method by calling self over COM-RPC.
+            // When running OOP, these calls traverse the proxy/stub boundary.
+
+            BenchmarkMethod("SendUint32", iterations, [this]() {
+                SendUint32(42);
+            });
+
+            BenchmarkMethod("SendUint64", iterations, [this]() {
+                SendUint64(UINT64_C(123456789));
+            });
+
+            BenchmarkMethod("SendString", iterations, [this]() {
+                SendString(_T("benchmark_payload_string"));
+            });
+
+            BenchmarkMethod("SendSampleData", iterations, [this]() {
+                QualityAssurance::SampleData data;
+                data.id = 1;
+                data.value = 100;
+                data.name = _T("sample");
+                SendSampleData(data);
+            });
+
+            BenchmarkMethod("SendWithNoParameters", iterations, [this]() {
+                SendWithNoParameters();
+            });
+
+            BenchmarkMethod("SendReceiveUint32", iterations, [this]() {
+                uint32_t out = 0;
+                SendReceiveUint32(42, out);
+            });
+
+            BenchmarkMethod("SendReceiveString", iterations, [this]() {
+                string out;
+                SendReceiveString(_T("benchmark_roundtrip"), out);
+            });
+
+            BenchmarkMethod("SendReceiveSampleData", iterations, [this]() {
+                QualityAssurance::SampleData in;
+                in.id = 1;
+                in.value = 200;
+                in.name = _T("roundtrip");
+                QualityAssurance::SampleData out;
+                SendReceiveSampleData(in, out);
+            });
+
+            BenchmarkMethod("Add", iterations, [this]() {
+                uint32_t result = 0;
+                Add(17, 25, result);
+            });
+        }
+
+        template<typename CALLABLE>
+        void BenchmarkMethod(const string& apiName, uint32_t iterations, CALLABLE&& fn)
+        {
+            Core::ProcessInfo processInfo(Core::ProcessInfo().Id());
+
+            // Capture memory before
+            uint64_t residentBefore = processInfo.Resident();
+            uint64_t allocatedBefore = processInfo.Allocated();
+
+            LatencyAccumulator acc;
+
+            // Time each call individually for min/max
+            for (uint32_t i = 0; i < iterations; i++) {
+                Core::StopWatch timer;
+                fn();
+                uint64_t elapsedUs = timer.Elapsed();
+                acc.Record(elapsedUs);
+            }
+
+            // Also time the entire batch for accurate average
+            Core::StopWatch batchTimer;
+            for (uint32_t i = 0; i < iterations; i++) {
+                fn();
+            }
+            uint64_t totalBatchUs = batchTimer.Elapsed();
+
+            // Capture memory after
+            uint64_t residentAfter = processInfo.Resident();
+            uint64_t allocatedAfter = processInfo.Allocated();
+
+            BenchmarkResult result;
+            result.apiName = apiName;
+            result.iterations = iterations;
+            result.roundTrip = acc.Stats();
+            // Override avgNs with batch-derived value for better precision
+            if (iterations > 0) {
+                result.roundTrip.avgNs = (totalBatchUs * 1000) / iterations;
+            }
+            result.memory.residentBefore = residentBefore;
+            result.memory.residentAfter = residentAfter;
+            result.memory.allocatedBefore = allocatedBefore;
+            result.memory.allocatedAfter = allocatedAfter;
+
+            _adminLock.Lock();
+            _results.push_back(result);
+            _adminLock.Unlock();
+        }
+
+    private:
+        mutable Core::CriticalSection _adminLock;
+        std::vector<BenchmarkResult> _results;
+        std::vector<IBenchmark::INotification*> _notifications;
+        std::map<string, BenchmarkResult> _baselines;
+        float _maxLatencyDeviationPct;
+        uint64_t _maxMemoryGrowthBytes;
+    };
+
+    SERVICE_REGISTRATION(BenchmarkImplementation, 1, 0)
+
+} // namespace Plugin
+} // namespace Thunder

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -22,10 +22,6 @@
 #include <qa_interfaces/IBenchmarkPayloadCOMRPC.h>
 
 #include <algorithm>
-#include <cinttypes>
-#include <cmath>
-#include <cstdio>
-#include <map>
 #include <vector>
 
 namespace Thunder {
@@ -34,49 +30,6 @@ namespace Plugin {
     class BenchmarkImplementation
         : public QualityAssurance::IBenchmark
         , public QualityAssurance::IBenchmarkPayload {
-    private:
-        struct LatencyAccumulator {
-            std::vector<uint64_t> samplesUs;
-
-            void Record(uint64_t us)
-            {
-                samplesUs.push_back(us);
-            }
-
-            QualityAssurance::IBenchmark::RoundTripStats Stats() const
-            {
-                QualityAssurance::IBenchmark::RoundTripStats stats{};
-                if (samplesUs.empty()) return stats;
-
-                uint64_t sum = 0;
-                uint64_t minVal = UINT64_MAX;
-                uint64_t maxVal = 0;
-
-                for (auto v : samplesUs) {
-                    sum += v;
-                    if (v < minVal) minVal = v;
-                    if (v > maxVal) maxVal = v;
-                }
-
-                uint64_t avg = sum / samplesUs.size();
-
-                double variance = 0.0;
-                for (auto v : samplesUs) {
-                    double diff = static_cast<double>(v) - static_cast<double>(avg);
-                    variance += diff * diff;
-                }
-                variance /= samplesUs.size();
-
-                // Convert µs to ns for the interface
-                stats.minNs = minVal * 1000;
-                stats.avgNs = avg * 1000;
-                stats.maxNs = maxVal * 1000;
-                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance)) * 1000;
-
-                return stats;
-            }
-        };
-
     public:
         BenchmarkImplementation(const BenchmarkImplementation&) = delete;
         BenchmarkImplementation& operator=(const BenchmarkImplementation&) = delete;
@@ -85,11 +38,7 @@ namespace Plugin {
 
         BenchmarkImplementation()
             : _adminLock()
-            , _results()
             , _notifications()
-            , _baselines()
-            , _maxLatencyDeviationPct(0.0f)
-            , _maxMemoryGrowthBytes(0)
         {
         }
 
@@ -106,87 +55,31 @@ namespace Plugin {
 
         Core::hresult Trigger(const uint32_t iterations, bool& success) override
         {
+            // Measurement is performed on the plugin shell side via the IBenchmarkPayload COM-RPC proxy.
+            // This method is retained for interface compliance and notification forwarding.
             _adminLock.Lock();
-            _results.clear();
+            std::vector<IBenchmark::INotification*> sinks(_notifications);
+            for (auto* sink : sinks) {
+                sink->AddRef();
+            }
             _adminLock.Unlock();
 
-            RunPayloadBenchmarks(iterations);
-
-            // Apply pass/fail thresholds
-            _adminLock.Lock();
-            bool hasThresholds = (_maxLatencyDeviationPct > 0.0f || _maxMemoryGrowthBytes > 0);
-
-            if (hasThresholds && _baselines.empty()) {
-                // First run with thresholds set: store as baseline, everything passes
-                for (auto& r : _results) {
-                    _baselines[r.apiName] = r;
-                    r.passed = true;
-                }
-            } else if (hasThresholds) {
-                // Subsequent runs: compare against baseline
-                for (auto& r : _results) {
-                    r.passed = true;
-                    r.failureReason = string();
-
-                    auto baseline = _baselines.find(r.apiName);
-                    if (baseline != _baselines.end()) {
-                        // Latency check
-                        if (_maxLatencyDeviationPct > 0.0f && baseline->second.roundTrip.avgNs > 0) {
-                            double baselineAvg = static_cast<double>(baseline->second.roundTrip.avgNs);
-                            double currentAvg = static_cast<double>(r.roundTrip.avgNs);
-                            double deviationPct = ((currentAvg - baselineAvg) / baselineAvg) * 100.0;
-                            if (deviationPct > static_cast<double>(_maxLatencyDeviationPct)) {
-                                r.passed = false;
-                                char buf[256];
-                                snprintf(buf, sizeof(buf), "latency deviation %.1f%% exceeds %.1f%% threshold (baseline=%" PRIu64 " ns, current=%" PRIu64 " ns)",
-                                    deviationPct, static_cast<double>(_maxLatencyDeviationPct),
-                                    baseline->second.roundTrip.avgNs, r.roundTrip.avgNs);
-                                r.failureReason = string(buf);
-                            }
-                        }
-                        // Memory check
-                        if (_maxMemoryGrowthBytes > 0) {
-                            int64_t growth = static_cast<int64_t>(r.memory.residentAfter) - static_cast<int64_t>(r.memory.residentBefore);
-                            if (growth > 0 && static_cast<uint64_t>(growth) > _maxMemoryGrowthBytes) {
-                                r.passed = false;
-                                char buf[256];
-                                snprintf(buf, sizeof(buf), "memory growth %" PRId64 " bytes exceeds %" PRIu64 " byte threshold",
-                                    growth, _maxMemoryGrowthBytes);
-                                string memMsg(buf);
-                                if (!r.failureReason.empty()) {
-                                    r.failureReason += "; ";
-                                }
-                                r.failureReason += memMsg;
-                            }
-                        }
-                    }
-                }
-            } else {
-                // No thresholds: everything passes
-                for (auto& r : _results) {
-                    r.passed = true;
-                }
-            }
-
-            // Notify listeners
-            for (auto* sink : _notifications) {
+            for (auto* sink : sinks) {
                 sink->PerformanceCheckCompleted();
+                sink->Release();
             }
-            _adminLock.Unlock();
 
             success = true;
-            TRACE(Trace::Information, (_T("Benchmark completed: %u iterations"), iterations));
+            TRACE(Trace::Information, (_T("Benchmark Trigger called: %u iterations (measurement on shell side)"), iterations));
             return Core::ERROR_NONE;
         }
 
         Core::hresult CollectData(IBenchmarkResultIterator*& report) const override
         {
-            _adminLock.Lock();
-            std::vector<BenchmarkResult> items(_results);
-            _adminLock.Unlock();
-
+            // Results are stored on the plugin shell side.
+            std::vector<BenchmarkResult> empty;
             using Iterator = RPC::IteratorType<IBenchmarkResultIterator>;
-            report = Core::ServiceType<Iterator>::Create<IBenchmarkResultIterator>(items);
+            report = Core::ServiceType<Iterator>::Create<IBenchmarkResultIterator>(empty);
 
             return Core::ERROR_NONE;
         }
@@ -215,18 +108,10 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        Core::hresult SetThreshold(const float maxLatencyDeviationPct, const uint64_t maxMemoryGrowthBytes, bool& success) override
+        Core::hresult SetThreshold(const float /* maxLatencyDeviationPct */, const uint64_t /* maxMemoryGrowthBytes */, bool& success) override
         {
-            _adminLock.Lock();
-            _maxLatencyDeviationPct = maxLatencyDeviationPct;
-            _maxMemoryGrowthBytes = maxMemoryGrowthBytes;
-            // Clear baselines so the next Trigger run becomes the new baseline
-            _baselines.clear();
-            _adminLock.Unlock();
-
+            // Thresholds are managed on the plugin shell side.
             success = true;
-            TRACE(Trace::Information, (_T("Thresholds set: latency=%.1f%%, memory=%llu bytes"),
-                maxLatencyDeviationPct, maxMemoryGrowthBytes));
             return Core::ERROR_NONE;
         }
 
@@ -327,115 +212,8 @@ namespace Plugin {
         }
 
     private:
-        void RunPayloadBenchmarks(uint32_t iterations)
-        {
-            // Benchmark each IBenchmarkPayload method by calling self over COM-RPC.
-            // When running OOP, these calls traverse the proxy/stub boundary.
-
-            BenchmarkMethod("SendUint32", iterations, [this]() {
-                SendUint32(42);
-            });
-
-            BenchmarkMethod("SendUint64", iterations, [this]() {
-                SendUint64(UINT64_C(123456789));
-            });
-
-            BenchmarkMethod("SendString", iterations, [this]() {
-                SendString(_T("benchmark_payload_string"));
-            });
-
-            BenchmarkMethod("SendSampleData", iterations, [this]() {
-                QualityAssurance::SampleData data;
-                data.id = 1;
-                data.value = 100;
-                data.name = _T("sample");
-                SendSampleData(data);
-            });
-
-            BenchmarkMethod("SendWithNoParameters", iterations, [this]() {
-                SendWithNoParameters();
-            });
-
-            BenchmarkMethod("SendReceiveUint32", iterations, [this]() {
-                uint32_t out = 0;
-                SendReceiveUint32(42, out);
-            });
-
-            BenchmarkMethod("SendReceiveString", iterations, [this]() {
-                string out;
-                SendReceiveString(_T("benchmark_roundtrip"), out);
-            });
-
-            BenchmarkMethod("SendReceiveSampleData", iterations, [this]() {
-                QualityAssurance::SampleData in;
-                in.id = 1;
-                in.value = 200;
-                in.name = _T("roundtrip");
-                QualityAssurance::SampleData out;
-                SendReceiveSampleData(in, out);
-            });
-
-            BenchmarkMethod("Add", iterations, [this]() {
-                uint32_t result = 0;
-                Add(17, 25, result);
-            });
-        }
-
-        template<typename CALLABLE>
-        void BenchmarkMethod(const string& apiName, uint32_t iterations, CALLABLE&& fn)
-        {
-            Core::ProcessInfo processInfo(Core::ProcessInfo().Id());
-
-            // Capture memory before
-            uint64_t residentBefore = processInfo.Resident();
-            uint64_t allocatedBefore = processInfo.Allocated();
-
-            LatencyAccumulator acc;
-
-            // Time each call individually for min/max
-            for (uint32_t i = 0; i < iterations; i++) {
-                Core::StopWatch timer;
-                fn();
-                uint64_t elapsedUs = timer.Elapsed();
-                acc.Record(elapsedUs);
-            }
-
-            // Also time the entire batch for accurate average
-            Core::StopWatch batchTimer;
-            for (uint32_t i = 0; i < iterations; i++) {
-                fn();
-            }
-            uint64_t totalBatchUs = batchTimer.Elapsed();
-
-            // Capture memory after
-            uint64_t residentAfter = processInfo.Resident();
-            uint64_t allocatedAfter = processInfo.Allocated();
-
-            BenchmarkResult result;
-            result.apiName = apiName;
-            result.iterations = iterations;
-            result.roundTrip = acc.Stats();
-            // Override avgNs with batch-derived value for better precision
-            if (iterations > 0) {
-                result.roundTrip.avgNs = (totalBatchUs * 1000) / iterations;
-            }
-            result.memory.residentBefore = residentBefore;
-            result.memory.residentAfter = residentAfter;
-            result.memory.allocatedBefore = allocatedBefore;
-            result.memory.allocatedAfter = allocatedAfter;
-
-            _adminLock.Lock();
-            _results.push_back(result);
-            _adminLock.Unlock();
-        }
-
-    private:
         mutable Core::CriticalSection _adminLock;
-        std::vector<BenchmarkResult> _results;
         std::vector<IBenchmark::INotification*> _notifications;
-        std::map<string, BenchmarkResult> _baselines;
-        float _maxLatencyDeviationPct;
-        uint64_t _maxMemoryGrowthBytes;
     };
 
     SERVICE_REGISTRATION(BenchmarkImplementation, 1, 0)

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -71,7 +71,7 @@ namespace Plugin {
                 stats.minNs = minVal * 1000;
                 stats.avgNs = avg * 1000;
                 stats.maxNs = maxVal * 1000;
-                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance)) * 1000;
+                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance) * 1000.0);
 
                 return stats;
             }

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -107,9 +107,27 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        Core::hresult SetThreshold(const uint32_t /* maxLatencyDeviationPct */, const uint64_t /* maxMemoryGrowthBytes */) override
+        Core::hresult LatencyThreshold(const uint32_t /* maxLatencyDeviationPct */) override
         {
             // Thresholds are managed on the plugin shell side.
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult LatencyThreshold(uint32_t& maxLatencyDeviationPct) const override
+        {
+            maxLatencyDeviationPct = 0;
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult MemoryThreshold(const uint64_t /* maxMemoryGrowthBytes */) override
+        {
+            // Thresholds are managed on the plugin shell side.
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult MemoryThreshold(uint64_t& maxMemoryGrowthBytes) const override
+        {
+            maxMemoryGrowthBytes = 0;
             return Core::ERROR_NONE;
         }
 
@@ -143,6 +161,11 @@ namespace Plugin {
         Core::hresult SendNoPayload() override { return Core::ERROR_NONE; }
 
         Core::hresult SendBuffer(const uint16_t /* bufferSize */, const uint8_t[] /* buffer */) override
+        {
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult SendUint32Array(const std::vector<uint32_t>& /* data */) override
         {
             return Core::ERROR_NONE;
         }
@@ -200,6 +223,12 @@ namespace Plugin {
             // Echo — buffer and size remain unchanged
             (void)bufferSize;
             (void)buffer;
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult SendReceiveUint32Array(const std::vector<uint32_t>& input, std::vector<uint32_t>& output) const override
+        {
+            output = input;
             return Core::ERROR_NONE;
         }
 

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -165,7 +165,7 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        Core::hresult SendUint32Array(const std::vector<uint32_t>& /* data */) override
+        Core::hresult SendUint32Vector(const std::vector<uint32_t>& /* data */) override
         {
             return Core::ERROR_NONE;
         }
@@ -226,7 +226,7 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        Core::hresult SendReceiveUint32Array(const std::vector<uint32_t>& input, std::vector<uint32_t>& output) const override
+        Core::hresult SendReceiveUint32Vector(const std::vector<uint32_t>& input, std::vector<uint32_t>& output) const override
         {
             output = input;
             return Core::ERROR_NONE;

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -19,7 +19,7 @@
 
 #include "Module.h"
 #include <qa_interfaces/IBenchmark.h>
-#include <qa_interfaces/IBenchmarkPayloadCOMRPC.h>
+#include <qa_interfaces/IBenchmarkPayload.h>
 
 #include <algorithm>
 #include <vector>
@@ -53,7 +53,7 @@ namespace Plugin {
         // IBenchmark
         // -------------------------------------------------------------------
 
-        Core::hresult Trigger(const uint32_t iterations, bool& success) override
+        Core::hresult Trigger(const uint32_t iterations) override
         {
             // Measurement is performed on the plugin shell side via the IBenchmarkPayload COM-RPC proxy.
             // This method is retained for interface compliance and notification forwarding.
@@ -69,7 +69,6 @@ namespace Plugin {
                 sink->Release();
             }
 
-            success = true;
             TRACE(Trace::Information, (_T("Benchmark Trigger called: %u iterations (measurement on shell side)"), iterations));
             return Core::ERROR_NONE;
         }
@@ -84,19 +83,19 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        Core::hresult Register(const IBenchmark::INotification* sink) override
+        Core::hresult Register(IBenchmark::INotification* sink) override
         {
             _adminLock.Lock();
             auto it = std::find(_notifications.begin(), _notifications.end(), sink);
             if (it == _notifications.end()) {
-                _notifications.push_back(const_cast<IBenchmark::INotification*>(sink));
+                _notifications.push_back(sink);
                 sink->AddRef();
             }
             _adminLock.Unlock();
             return Core::ERROR_NONE;
         }
 
-        Core::hresult Unregister(const IBenchmark::INotification* sink) override
+        Core::hresult Unregister(IBenchmark::INotification* sink) override
         {
             _adminLock.Lock();
             auto it = std::find(_notifications.begin(), _notifications.end(), sink);
@@ -108,10 +107,9 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        Core::hresult SetThreshold(const float /* maxLatencyDeviationPct */, const uint64_t /* maxMemoryGrowthBytes */, bool& success) override
+        Core::hresult SetThreshold(const uint32_t /* maxLatencyDeviationPct */, const uint64_t /* maxMemoryGrowthBytes */) override
         {
             // Thresholds are managed on the plugin shell side.
-            success = true;
             return Core::ERROR_NONE;
         }
 
@@ -119,7 +117,7 @@ namespace Plugin {
         // IBenchmarkPayload — echo/loopback endpoints for COM-RPC measurement
         // -------------------------------------------------------------------
 
-        uint32_t GetPayloadTypes(IPayloadTypeIterator*& types) const override
+        Core::hresult GetPayloadTypes(IPayloadTypeIterator*& types) const override
         {
             std::vector<PayloadType> payloads = {
                 PAYLOAD_SMALL, PAYLOAD_MEDIUM, PAYLOAD_LARGE
@@ -129,75 +127,75 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendUint16(const uint16_t /* value */) override { return Core::ERROR_NONE; }
-        uint32_t SendUint32(const uint32_t /* value */) override { return Core::ERROR_NONE; }
-        uint32_t SendUint64(const uint64_t /* value */) override { return Core::ERROR_NONE; }
-        uint32_t SendBool(const bool /* value */) override { return Core::ERROR_NONE; }
-        uint32_t SendFloat(const float /* value */) override { return Core::ERROR_NONE; }
-        uint32_t SendDouble(const double /* value */) override { return Core::ERROR_NONE; }
-        uint32_t SendString(const string& /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendUint16(const uint16_t /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendUint32(const uint32_t /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendUint64(const uint64_t /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendBool(const bool /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendFloat(const float /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendDouble(const double /* value */) override { return Core::ERROR_NONE; }
+        Core::hresult SendString(const string& /* value */) override { return Core::ERROR_NONE; }
 
-        uint32_t SendSampleData(const QualityAssurance::SampleData& /* data */) override
+        Core::hresult SendSampleData(const IBenchmarkPayload::SampleData& /* data */) override
         {
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendWithNoParameters() override { return Core::ERROR_NONE; }
+        Core::hresult SendNoPayload() override { return Core::ERROR_NONE; }
 
-        uint32_t SendBuffer(const uint16_t /* bufferSize */, const uint8_t[] /* buffer */) override
+        Core::hresult SendBuffer(const uint16_t /* bufferSize */, const uint8_t[] /* buffer */) override
         {
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveUint16(const uint16_t input, uint16_t& output) const override
-        {
-            output = input;
-            return Core::ERROR_NONE;
-        }
-
-        uint32_t SendReceiveUint32(const uint32_t input, uint32_t& output) const override
+        Core::hresult SendReceiveUint16(const uint16_t input, uint16_t& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveUint64(const uint64_t input, uint64_t& output) const override
+        Core::hresult SendReceiveUint32(const uint32_t input, uint32_t& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveBool(const bool input, bool& output) const override
+        Core::hresult SendReceiveUint64(const uint64_t input, uint64_t& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveFloat(const float input, float& output) const override
+        Core::hresult SendReceiveBool(const bool input, bool& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveDouble(const double input, double& output) const override
+        Core::hresult SendReceiveFloat(const float input, float& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveString(const string& input, string& output) const override
+        Core::hresult SendReceiveDouble(const double input, double& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveSampleData(const QualityAssurance::SampleData& input, QualityAssurance::SampleData& output) const override
+        Core::hresult SendReceiveString(const string& input, string& output) const override
         {
             output = input;
             return Core::ERROR_NONE;
         }
 
-        uint32_t SendReceiveBuffer(uint16_t& bufferSize, uint8_t buffer[]) const override
+        Core::hresult SendReceiveSampleData(const IBenchmarkPayload::SampleData& input, IBenchmarkPayload::SampleData& output) const override
+        {
+            output = input;
+            return Core::ERROR_NONE;
+        }
+
+        Core::hresult SendReceiveBuffer(uint16_t& bufferSize, uint8_t buffer[]) const override
         {
             // Echo — buffer and size remain unchanged
             (void)bufferSize;
@@ -205,7 +203,7 @@ namespace Plugin {
             return Core::ERROR_NONE;
         }
 
-        uint32_t Add(const uint32_t a, const uint32_t b, uint32_t& result) const override
+        Core::hresult Add(const uint32_t a, const uint32_t b, uint32_t& result) const override
         {
             result = a + b;
             return Core::ERROR_NONE;

--- a/tests/Benchmark/BenchmarkImplementation.cpp
+++ b/tests/Benchmark/BenchmarkImplementation.cpp
@@ -71,7 +71,7 @@ namespace Plugin {
                 stats.minNs = minVal * 1000;
                 stats.avgNs = avg * 1000;
                 stats.maxNs = maxVal * 1000;
-                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance) * 1000.0);
+                stats.stddevNs = static_cast<uint64_t>(std::sqrt(variance)) * 1000;
 
                 return stats;
             }

--- a/tests/Benchmark/BenchmarkPlugin.json
+++ b/tests/Benchmark/BenchmarkPlugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "plugin.schema.json",
+  "info": {
+    "title": "Benchmark Plugin",
+    "callsign": "Benchmark",
+    "locator": "libThunderBenchmark.so",
+    "status": "alpha",
+    "description": "The Benchmark plugin measures COM-RPC call latency and memory usage for various payload types, with support for threshold-based pass/fail regression detection.",
+    "version": "1.0"
+  },
+  "interface": {
+    "$ref": "{interfacedir}/Benchmark.json#"
+  }
+}

--- a/tests/Benchmark/CMakeLists.txt
+++ b/tests/Benchmark/CMakeLists.txt
@@ -1,0 +1,67 @@
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright 2024 Metrological
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project(Benchmark)
+
+cmake_minimum_required(VERSION 3.15)
+
+find_package(Thunder)
+
+project_version(1.0.0)
+
+set(MODULE_NAME ${NAMESPACE}${PROJECT_NAME})
+
+message("Setup ${MODULE_NAME} v${PROJECT_VERSION}")
+
+set(PLUGIN_BENCHMARK_STARTMODE "Activated" CACHE STRING "Automatically start Benchmark plugin")
+set(PLUGIN_BENCHMARK_RESUMED "true" CACHE STRING "Set Benchmark resume state")
+set(PLUGIN_BENCHMARK_MODE "Local" CACHE STRING "Controls if the Benchmark plugin should run in its own process, in process or remote.")
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+find_package(${NAMESPACE}Tracing REQUIRED)
+
+find_package(CompileSettingsDebug CONFIG REQUIRED)
+
+if(BUILD_REFERENCE)
+    add_definitions(-DBUILD_REFERENCE=${BUILD_REFERENCE})
+endif()
+
+add_library(${MODULE_NAME} SHARED
+        Module.cpp
+        Benchmark.cpp
+        BenchmarkImplementation.cpp)
+
+target_link_libraries(${MODULE_NAME}
+    PRIVATE
+        CompileSettingsDebug::CompileSettingsDebug
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${NAMESPACE}Tracing::${NAMESPACE}Tracing
+    PUBLIC
+        ${EXTRA_LIBS}
+    )
+
+set_target_properties(${MODULE_NAME}
+    PROPERTIES
+        CXX_STANDARD ${CXX_STD}
+        CXX_STANDARD_REQUIRED YES)
+
+install(TARGETS ${MODULE_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${STORAGE_DIRECTORY}/plugins COMPONENT ${NAMESPACE}_Test)
+
+write_config()

--- a/tests/Benchmark/CMakeLists.txt
+++ b/tests/Benchmark/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(${NAMESPACE}Tracing REQUIRED)
+find_package(${NAMESPACE}Definitions REQUIRED)
 
 find_package(CompileSettingsDebug CONFIG REQUIRED)
 
@@ -52,6 +53,7 @@ target_link_libraries(${MODULE_NAME}
         CompileSettingsDebug::CompileSettingsDebug
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
         ${NAMESPACE}Tracing::${NAMESPACE}Tracing
+        ${NAMESPACE}Definitions::${NAMESPACE}Definitions
     PUBLIC
         ${EXTRA_LIBS}
     )

--- a/tests/Benchmark/Module.cpp
+++ b/tests/Benchmark/Module.cpp
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/tests/Benchmark/Module.h
+++ b/tests/Benchmark/Module.h
@@ -1,0 +1,30 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_Benchmark
+#endif
+
+#include <plugins/plugins.h>
+#include <messaging/messaging.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ option(PLUGIN_TESTCONTROLLER "Include TestController plugin" OFF)
 option(PLUGIN_TESTUTILITY "Include TestUtility plugin" OFF)
 option(PLUGIN_TESTTEXTOPTIONS "Utility to verify the name of JSONRPC functions" OFF)
 option(PLUGIN_TESTPRIORITYQUEUE "Utility to verify the PriorityQueue implementation" OFF)
+option(PLUGIN_BENCHMARK "Include Benchmark plugin for COM-RPC performance measurement and regression detection" OFF)
 
 if(STORE_TEST)
     add_subdirectory(StoreTest)
@@ -55,4 +56,8 @@ endif()
 
 if(PLUGIN_TESTPRIORITYQUEUE)
     add_subdirectory(TestPriorityQueue)
+endif()
+
+if(PLUGIN_BENCHMARK)
+    add_subdirectory(Benchmark)
 endif()


### PR DESCRIPTION
- Add Benchmark plugin: measures per-API round-trip latency (ns)
  and RSS memory usage across COM-RPC payload types including
  scalars, strings, structs, iterators, and std::vector
- Support in-process and OOP (Local) execution modes; memory
  stats automatically target the correct process via IMemory
- Implement threshold-based pass/fail via LatencyThreshold and
  MemoryThreshold properties (millipercent and bytes); Trigger
  compares subsequent runs against a stored baseline and returns
  ERROR_GENERAL if any method exceeds configured limits
- Check COM-RPC return values on every iteration; abort early
  and mark result as failed on remote call errors
- Add FailureReason enum (LATENCY_THRESHOLD_EXCEEDED,
  MEMORY_THRESHOLD_EXCEEDED, LATENCY_AND_MEMORY_THRESHOLD_EXCEEDED)
- Fire PerformanceCheckCompleted event after each Trigger run
- Use @json 2.0.0 for PascalCase JSON-RPC method names